### PR TITLE
Fixed the CloudFormation UpdateProvisioningTemplate API

### DIFF
--- a/aws-iot-provisioningtemplate/src/main/java/com/amazonaws/iot/provisioningtemplate/UpdateHandler.java
+++ b/aws-iot-provisioningtemplate/src/main/java/com/amazonaws/iot/provisioningtemplate/UpdateHandler.java
@@ -40,6 +40,23 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         this.iotClient = iotClient;
     }
 
+    /**
+     * Get the pre-provisioning hook associated with the resource model or null if it does not exist.
+     * @param model The desired resource state
+     * @return A converted ProvisioningHook or null
+     */
+    private static ProvisioningHook getPreProvisioningHook(final ResourceModel model) {
+        final com.amazonaws.iot.provisioningtemplate.ProvisioningHook hook = model.getPreProvisioningHook();
+        if (hook == null) {
+            return null;
+        }
+
+        return ProvisioningHook.builder()
+                .payloadVersion(hook.getPayloadVersion())
+                .targetArn(hook.getTargetArn())
+                .build();
+    }
+
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
@@ -103,6 +120,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .description(newModel.getDescription())
                     .enabled(newModel.getEnabled())
                     .provisioningRoleArn(newModel.getProvisioningRoleArn())
+                    .preProvisioningHook(getPreProvisioningHook(newModel))
                     .build();
             currentRequest = updateRequest;
             proxy.injectCredentialsAndInvokeV2(updateRequest, iotClient::updateProvisioningTemplate);


### PR DESCRIPTION
Fixed the UpdateProvisioningTemplate API so that it includes the preProvisioningHook parameter.

*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-iot/issues/10

*Description of changes:*

When updating a provisioning template in CloudFormation the preProvisioningHook hook parameter was being ignored because it is missing from the sources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
