### PR TITLE
Add chenges to accomodate new custom metric changes to SecurityProfil…

### DIFF
--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/DeleteHandler.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/DeleteHandler.java
@@ -3,13 +3,19 @@ package com.amazonaws.iot.dimension;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.DeleteDimensionRequest;
 import software.amazon.awssdk.services.iot.model.DescribeDimensionRequest;
-import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.regex.Pattern;
+
+
 public class DeleteHandler extends BaseHandler<CallbackContext> {
+
+    private static final Pattern RESOURCE_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9:_-]+");
 
     private final IotClient iotClient;
 
@@ -30,8 +36,25 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
         // "A delete handler MUST return FAILED with a NotFound error code if the
         // resource did not exist prior to the delete request."
         // DeleteDimension API is idempotent, so we have to call Describe first.
+
+        // Before we call Describe, we also need to deal with an InvalidRequest edge case.
+        // If CFN is trying to delete a resource with an invalid name, returning InvalidRequest would
+        // get CFN stuck in delete-failed state. If we return NotFound, it'll just succeed.
+        // We wouldn't have to do this if aws-cloudformation-rpdk-java-plugin had functioning regex
+        // pattern evaluation (known issue with an internal ticket).
+        String dimensionName = model.getName();
+        boolean matches = RESOURCE_NAME_PATTERN.matcher(dimensionName).matches();
+        if (!matches) {
+            logger.log("Returning NotFound from DeleteHandler due to invalid name " + dimensionName);
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .resourceModel(model)
+                    .status(OperationStatus.FAILED)
+                    .errorCode(HandlerErrorCode.NotFound)
+                    .build();
+        }
+
         DescribeDimensionRequest describeRequest = DescribeDimensionRequest.builder()
-                .name(model.getName())
+                .name(dimensionName)
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(describeRequest, iotClient::describeDimension);
@@ -42,10 +65,10 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             return Translator.translateExceptionToErrorCode(model, e, logger);
         }
         logger.log(String.format("Called Describe for %s with name %s, accountId %s.",
-                ResourceModel.TYPE_NAME, model.getName(), request.getAwsAccountId()));
+                ResourceModel.TYPE_NAME, dimensionName, request.getAwsAccountId()));
 
         DeleteDimensionRequest deleteRequest = DeleteDimensionRequest.builder()
-                .name(model.getName())
+                .name(dimensionName)
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(deleteRequest, iotClient::deleteDimension);
@@ -54,7 +77,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
         }
 
         logger.log(String.format("Deleted %s with name %s, accountId %s.",
-                ResourceModel.TYPE_NAME, model.getName(), request.getAwsAccountId()));
+                ResourceModel.TYPE_NAME, dimensionName, request.getAwsAccountId()));
 
         return ProgressEvent.defaultSuccessHandler(null);
     }

--- a/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/DeleteHandlerTest.java
+++ b/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/DeleteHandlerTest.java
@@ -1,12 +1,5 @@
 package com.amazonaws.iot.dimension;
 
-import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_NAME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +17,14 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest {
@@ -88,6 +89,24 @@ public class DeleteHandlerTest {
 
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))
                 .thenThrow(ResourceNotFoundException.builder().build());
+
+        ProgressEvent<ResourceModel, CallbackContext> progressEvent =
+                handler.handleRequest(proxy, request, null, logger);
+        assertThat(progressEvent.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
+    }
+
+    @Test
+    public void handleRequest_InvalidName_ReturnNotFound() {
+
+        ResourceModel model = ResourceModel.builder()
+                .name("Tilde~")
+                .build();
+
+        ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        verifyZeroInteractions(proxy);
 
         ProgressEvent<ResourceModel, CallbackContext> progressEvent =
                 handler.handleRequest(proxy, request, null, logger);

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/DeleteHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/DeleteHandler.java
@@ -3,11 +3,17 @@ package com.amazonaws.iot.scheduledaudit;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.DeleteScheduledAuditRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.regex.Pattern;
+
 public class DeleteHandler extends BaseHandler<CallbackContext> {
+
+    private static final Pattern RESOURCE_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9:_-]+");
 
     private final IotClient iotClient;
 
@@ -29,8 +35,26 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
         // resource did not exist prior to the delete request."
         // DeleteScheduledAudit API is NOT idempotent, so we do not need to call Describe.
 
+        // Before we call Describe, we also need to deal with an InvalidRequest edge case.
+        // If CFN is trying to delete a resource with an invalid name, returning InvalidRequest would
+        // get CFN stuck in delete-failed state. If we return NotFound, it'll just succeed.
+        // We wouldn't have to do this if aws-cloudformation-rpdk-java-plugin had functioning regex
+        // pattern evaluation (known issue with an internal ticket).
+        String scheduledAuditName = model.getScheduledAuditName();
+        boolean matches = RESOURCE_NAME_PATTERN.matcher(scheduledAuditName).matches();
+        if (!matches) {
+            logger.log("Returning NotFound from DeleteHandler due to invalid name " + scheduledAuditName);
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .resourceModel(model)
+                    .status(OperationStatus.FAILED)
+                    .errorCode(HandlerErrorCode.NotFound)
+                    .build();
+        }
+
+
+
         DeleteScheduledAuditRequest deleteRequest = DeleteScheduledAuditRequest.builder()
-                .scheduledAuditName(model.getScheduledAuditName())
+                .scheduledAuditName(scheduledAuditName)
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(deleteRequest, iotClient::deleteScheduledAudit);
@@ -39,7 +63,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
         }
 
         logger.log(String.format("Deleted %s with name %s, accountId %s.",
-                ResourceModel.TYPE_NAME, model.getScheduledAuditName(), request.getAwsAccountId()));
+                ResourceModel.TYPE_NAME, scheduledAuditName, request.getAwsAccountId()));
 
         return ProgressEvent.defaultSuccessHandler(null);
     }

--- a/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/DeleteHandlerTest.java
+++ b/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/DeleteHandlerTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -84,6 +85,24 @@ public class DeleteHandlerTest {
 
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))
                 .thenThrow(ResourceNotFoundException.builder().build());
+
+        ProgressEvent<ResourceModel, CallbackContext> progressEvent =
+                handler.handleRequest(proxy, request, null, logger);
+        assertThat(progressEvent.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
+    }
+
+    @Test
+    public void handleRequest_InvalidName_ReturnNotFound() {
+
+        ResourceModel model = ResourceModel.builder()
+                .scheduledAuditName("Tilde~")
+                .build();
+
+        ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        verifyZeroInteractions(proxy);
 
         ProgressEvent<ResourceModel, CallbackContext> progressEvent =
                 handler.handleRequest(proxy, request, null, logger);

--- a/aws-iot-securityprofile/aws-iot-securityprofile.json
+++ b/aws-iot-securityprofile/aws-iot-securityprofile.json
@@ -73,7 +73,9 @@
             "in-cidr-set",
             "not-in-cidr-set",
             "in-port-set",
-            "not-in-port-set"
+            "not-in-port-set",
+            "in-set",
+            "not-in-set"
           ]
         },
         "Value": {
@@ -128,6 +130,28 @@
             "type": "integer",
             "minimum": 0,
             "maximum": 65535
+          }
+        },
+        "Number": {
+          "description": "The numeral value of a metric.",
+          "type": "number"
+        },
+        "Numbers": {
+          "description": "The numeral values of a metric.",
+          "type": "array",
+          "uniqueItems": true,
+          "insertionOrder": false,
+          "items": {
+            "type": "number"
+          }
+        },
+        "Strings": {
+          "description": "The string values of a metric.",
+          "type": "array",
+          "uniqueItems": true,
+          "insertionOrder": false,
+          "items": {
+            "type": "string"
           }
         }
       },

--- a/aws-iot-securityprofile/pom.xml
+++ b/aws-iot-securityprofile/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>iot</artifactId>
-            <version>2.15.7</version>
+            <version>2.15.47</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/DeleteHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/DeleteHandler.java
@@ -4,11 +4,16 @@ import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.DeleteSecurityProfileRequest;
 import software.amazon.awssdk.services.iot.model.DescribeSecurityProfileRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import java.util.regex.Pattern;
 
 public class DeleteHandler extends BaseHandler<CallbackContext> {
+
+    private static final Pattern RESOURCE_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9:_-]+");
 
     private final IotClient iotClient;
 
@@ -29,8 +34,24 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
         // "A delete handler MUST return FAILED with a NotFound error code if the
         // resource did not exist prior to the delete request."
         // DeleteSecurityProfile API is idempotent, so we have to call Describe first.
+
+        // Before we call Describe, we also need to deal with an InvalidRequest edge case.
+        // If CFN is trying to delete a resource with an invalid name, returning InvalidRequest would
+        // get CFN stuck in delete-failed state. If we return NotFound, it'll just succeed.
+        // We wouldn't have to do this if aws-cloudformation-rpdk-java-plugin had functioning regex
+        // pattern evaluation (known issue with an internal ticket).
+        String securityProfileName = model.getSecurityProfileName();
+        boolean matches = RESOURCE_NAME_PATTERN.matcher(securityProfileName).matches();
+        if (!matches) {
+            logger.log("Returning NotFound from DeleteHandler due to invalid name " + securityProfileName);
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .resourceModel(model)
+                    .status(OperationStatus.FAILED)
+                    .errorCode(HandlerErrorCode.NotFound)
+                    .build();
+        }
         DescribeSecurityProfileRequest describeRequest = DescribeSecurityProfileRequest.builder()
-                .securityProfileName(model.getSecurityProfileName())
+                .securityProfileName(securityProfileName)
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(describeRequest, iotClient::describeSecurityProfile);
@@ -41,10 +62,10 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
         logger.log(String.format("Called Describe for %s with name %s, accountId %s.",
-                ResourceModel.TYPE_NAME, model.getSecurityProfileName(), request.getAwsAccountId()));
+                ResourceModel.TYPE_NAME, securityProfileName, request.getAwsAccountId()));
 
         DeleteSecurityProfileRequest deleteRequest = DeleteSecurityProfileRequest.builder()
-                .securityProfileName(model.getSecurityProfileName())
+                .securityProfileName(securityProfileName)
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(deleteRequest, iotClient::deleteSecurityProfile);
@@ -53,7 +74,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
         }
 
         logger.log(String.format("Deleted %s with name %s, accountId %s.",
-                ResourceModel.TYPE_NAME, model.getSecurityProfileName(), request.getAwsAccountId()));
+                ResourceModel.TYPE_NAME, securityProfileName, request.getAwsAccountId()));
 
         return ProgressEvent.defaultSuccessHandler(null);
     }

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/Translator.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/Translator.java
@@ -1,11 +1,5 @@
 package com.amazonaws.iot.securityprofile;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import lombok.NonNull;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.services.iot.model.InternalFailureException;
@@ -21,6 +15,12 @@ import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Translator {
 
@@ -112,7 +112,7 @@ public class Translator {
                 countLong = Long.parseLong(countStringFromCfn);
             } catch (NumberFormatException e) {
                 throw new CfnInvalidRequestException("Invalid value for Behavior::MetricValue::Count: " +
-                                                     countStringFromCfn);
+                        countStringFromCfn);
             }
         }
 
@@ -120,6 +120,9 @@ public class Translator {
                 .count(countLong)
                 .cidrs(cfnMetricValue.getCidrs())
                 .ports(cfnMetricValue.getPorts())
+                .number(cfnMetricValue.getNumber())
+                .numbers(cfnMetricValue.getNumbers())
+                .strings(cfnMetricValue.getStrings())
                 .build();
     }
 
@@ -133,6 +136,9 @@ public class Translator {
         if (iotMetricValue.count() != null) {
             metricValueBuilder.count(iotMetricValue.count().toString());
         }
+        if (iotMetricValue.number() != null) {
+            metricValueBuilder.number(iotMetricValue.number());
+        }
         // For lists, we're using the .has* methods to differentiate between null and empty lists
         // from DescribeSecurityProfileResponse.
         // SDK converts nulls from Describe API to empty DefaultSdkAutoConstructLists,
@@ -143,7 +149,12 @@ public class Translator {
         if (iotMetricValue.hasPorts()) {
             metricValueBuilder.ports(new HashSet<>(iotMetricValue.ports()));
         }
-
+        if (iotMetricValue.hasNumbers()) {
+            metricValueBuilder.numbers(new HashSet<>(iotMetricValue.numbers()));
+        }
+        if (iotMetricValue.hasStrings()) {
+            metricValueBuilder.strings(new HashSet<>(iotMetricValue.strings()));
+        }
         return metricValueBuilder.build();
     }
 

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/DeleteHandlerTest.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/DeleteHandlerTest.java
@@ -1,12 +1,5 @@
 package com.amazonaws.iot.securityprofile;
 
-import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_NAME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -24,6 +17,14 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 public class DeleteHandlerTest {
 
@@ -113,5 +114,23 @@ public class DeleteHandlerTest {
         ProgressEvent<ResourceModel, CallbackContext> progressEvent =
                 handler.handleRequest(proxy, request, null, logger);
         assertThat(progressEvent.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+    }
+
+    @Test
+    public void handleRequest_InvalidName_ReturnNotFound() {
+
+        ResourceModel model = ResourceModel.builder()
+                .securityProfileName("Exclamation!")
+                .build();
+
+        ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        verifyZeroInteractions(proxy);
+
+        ProgressEvent<ResourceModel, CallbackContext> progressEvent =
+                handler.handleRequest(proxy, request, null, logger);
+        assertThat(progressEvent.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 }

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TranslatorTest.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TranslatorTest.java
@@ -5,14 +5,18 @@ import org.junit.jupiter.api.Test;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import static com.amazonaws.iot.securityprofile.TestConstants.BEHAVIOR_NAME;
 import static com.amazonaws.iot.securityprofile.Translator.translateBehaviorListFromIotToCfn;
 import static com.amazonaws.iot.securityprofile.Translator.translateBehaviorSetFromCfnToIot;
 import static com.amazonaws.iot.securityprofile.Translator.translateMetricValueFromCfnToIot;
+import static com.amazonaws.iot.securityprofile.Translator.translateMetricValueFromIotToCfn;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TranslatorTest {
 
@@ -180,5 +184,48 @@ public class TranslatorTest {
                 .build();
         assertThatThrownBy(() -> translateMetricValueFromCfnToIot(cfnMetricValue))
                 .isInstanceOf(CfnInvalidRequestException.class);
+    }
+
+    @Test
+    void translateMetricValueFromCfnToIot_VerifyTranslation() {
+        Set<Double> setOfDoubles = ImmutableSet.of(123d, 456d);
+        Double numberDouble = 123d;
+        Set<String> setOfStrings = ImmutableSet.of("123", "456");
+        String stringCount = "123";
+        MetricValue cfnMetricValue = MetricValue.builder()
+                .count(stringCount)
+                .cidrs(setOfStrings)
+                .number(123d)
+                .numbers(setOfDoubles)
+                .strings(setOfStrings)
+                .build();
+        software.amazon.awssdk.services.iot.model.MetricValue metricValue =
+                translateMetricValueFromCfnToIot(cfnMetricValue);
+        assertTrue(metricValue.count().equals(Long.parseLong(stringCount)));
+        assertTrue(metricValue.number().equals(numberDouble));
+        assertTrue(metricValue.cidrs().size() == setOfStrings.size() && metricValue.cidrs().containsAll(setOfStrings));
+        assertTrue(metricValue.numbers().size() == setOfDoubles.size() && metricValue.numbers().containsAll(setOfDoubles));
+        assertTrue(metricValue.strings().size() == setOfStrings.size() && metricValue.strings().containsAll(setOfStrings));
+    }
+
+    @Test
+    void translateMetricValueFromIotToCfn_VerifyTranslation() {
+        List<String> listOfStrings = Arrays.asList("123", "456");
+        List<Double> listOfDoubles = Arrays.asList(123d, 456d);
+        Double numberDouble = 123d;
+        Long numberLong = 123l;
+        software.amazon.awssdk.services.iot.model.MetricValue iotMetricValue = software.amazon.awssdk.services.iot.model.MetricValue.builder()
+                .count(numberLong)
+                .number(numberDouble)
+                .numbers(listOfDoubles)
+                .cidrs(listOfStrings)
+                .strings(listOfStrings)
+                .build();
+        MetricValue metricValue = translateMetricValueFromIotToCfn(iotMetricValue);
+        assertTrue(metricValue.getCount().equals(numberLong.toString()));
+        assertTrue(metricValue.getNumber().equals(numberDouble));
+        assertTrue(metricValue.getNumbers().size() == listOfDoubles.size() && metricValue.getNumbers().containsAll(listOfDoubles));
+        assertTrue(metricValue.getCidrs().size() == listOfStrings.size() && metricValue.getCidrs().containsAll(listOfStrings));
+        assertTrue(metricValue.getStrings().size() == listOfStrings.size() && metricValue.getStrings().containsAll(listOfStrings));
     }
 }

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TranslatorTest.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TranslatorTest.java
@@ -1,19 +1,18 @@
 package com.amazonaws.iot.securityprofile;
 
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+
+import java.util.ArrayList;
+import java.util.Set;
+
 import static com.amazonaws.iot.securityprofile.TestConstants.BEHAVIOR_NAME;
 import static com.amazonaws.iot.securityprofile.Translator.translateBehaviorListFromIotToCfn;
 import static com.amazonaws.iot.securityprofile.Translator.translateBehaviorSetFromCfnToIot;
 import static com.amazonaws.iot.securityprofile.Translator.translateMetricValueFromCfnToIot;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.util.ArrayList;
-import java.util.Set;
-
-import com.google.common.collect.ImmutableSet;
-
-import org.junit.jupiter.api.Test;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 
 public class TranslatorTest {
 


### PR DESCRIPTION
Adding new metricTypes to accomodate custom metric types. Also adding a fix for delete handlers to compensate a shortcoming in CFN stack cleanup logic.

Ran all the contract tests locally.