### PR TITLE
Add workaround for cfn bug for ResourceAlreadyExist exception and oth…

### DIFF
--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/CreateHandler.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/CreateHandler.java
@@ -55,7 +55,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             describeResponse = proxy.injectCredentialsAndInvokeV2(
                     DescribeAccountAuditConfigurationRequest.builder().build(),
                     iotClient::describeAccountAuditConfiguration);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
         logger.log("Called DescribeAccountAuditConfiguration for " + accountId);
@@ -99,7 +99,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         try {
             proxy.injectCredentialsAndInvokeV2(
                     updateRequest, iotClient::updateAccountAuditConfiguration);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/CreateHandler.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/CreateHandler.java
@@ -1,8 +1,5 @@
 package com.amazonaws.iot.accountauditconfiguration;
 
-import java.util.Map;
-import java.util.Set;
-
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.AuditNotificationTarget;
 import software.amazon.awssdk.services.iot.model.DescribeAccountAuditConfigurationRequest;
@@ -10,11 +7,15 @@ import software.amazon.awssdk.services.iot.model.DescribeAccountAuditConfigurati
 import software.amazon.awssdk.services.iot.model.UpdateAccountAuditConfigurationRequest;
 import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.Map;
+import java.util.Set;
 
 public class CreateHandler extends BaseHandler<CallbackContext> {
 
@@ -79,8 +80,8 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             if (areEquivalent) {
                 return ProgressEvent.defaultSuccessHandler(model);
             } else {
-                return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.AlreadyExists,
-                        "A configuration with different properties already exists.");
+                throw new CfnAlreadyExistsException(
+                        new Throwable("A configuration with different properties already exists."));
             }
         }
         logger.log("DescribeAccountAuditConfiguration for " + accountId +
@@ -113,7 +114,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
 
         if (!describeResponse.roleArn().equals(model.getRoleArn())) {
             logger.log("AccountAuditConfiguration already exists with a different role ARN: " +
-                       describeResponse.roleArn());
+                    describeResponse.roleArn());
             return false;
         }
 
@@ -124,7 +125,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
 
         if (!areNotificationTargetsEquivalent(model, describeResponse)) {
             logger.log("AccountAuditConfiguration already exists with different notification " +
-                       "target configurations enabled.");
+                    "target configurations enabled.");
             return false;
         }
         return true;

--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/DeleteHandler.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/DeleteHandler.java
@@ -54,7 +54,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             describeResponse = proxy.injectCredentialsAndInvokeV2(
                     DescribeAccountAuditConfigurationRequest.builder().build(),
                     iotClient::describeAccountAuditConfiguration);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
         logger.log("Called DescribeAccountAuditConfiguration for " + accountId);
@@ -73,7 +73,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             proxy.injectCredentialsAndInvokeV2(
                     DeleteAccountAuditConfigurationRequest.builder().build(),
                     iotClient::deleteAccountAuditConfiguration);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/ListHandler.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/ListHandler.java
@@ -37,7 +37,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
             describeResponse = proxy.injectCredentialsAndInvokeV2(
                     DescribeAccountAuditConfigurationRequest.builder().build(),
                     iotClient::describeAccountAuditConfiguration);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(request.getDesiredResourceState(), e, logger);
         }
         logger.log("Called DescribeAccountAuditConfiguration for " + accountId);

--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/ReadHandler.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/ReadHandler.java
@@ -36,7 +36,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
             describeResponse = proxy.injectCredentialsAndInvokeV2(
                     DescribeAccountAuditConfigurationRequest.builder().build(),
                     iotClient::describeAccountAuditConfiguration);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(request.getDesiredResourceState(), e, logger);
         }
         logger.log("Called DescribeAccountAuditConfiguration for " + accountId);

--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/UpdateHandler.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/UpdateHandler.java
@@ -47,7 +47,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             describeResponse = proxy.injectCredentialsAndInvokeV2(
                     DescribeAccountAuditConfigurationRequest.builder().build(),
                     iotClient::describeAccountAuditConfiguration);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
         logger.log(String.format("Called DescribeAccountAuditConfiguration for %s.", accountId));
@@ -74,7 +74,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         try {
             proxy.injectCredentialsAndInvokeV2(
                     updateRequest, iotClient::updateAccountAuditConfiguration);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/CreateHandler.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/CreateHandler.java
@@ -48,10 +48,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         try {
             createCustomMetricResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createCustomMetric);
-        } catch (Exception e) {
-            if (e instanceof ResourceAlreadyExistsException) {
-                throw new CfnAlreadyExistsException(e);
-            }
+        } catch (ResourceAlreadyExistsException e) {
+            logger.log(String.format("Resource already exists %s.", model.getMetricName()));
+            throw new CfnAlreadyExistsException(e);
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/CreateHandler.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/CreateHandler.java
@@ -4,7 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.CreateCustomMetricRequest;
 import software.amazon.awssdk.services.iot.model.CreateCustomMetricResponse;
-import software.amazon.awssdk.services.iot.model.IotException;
+import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -48,6 +49,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             createCustomMetricResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createCustomMetric);
         } catch (Exception e) {
+            if (e instanceof ResourceAlreadyExistsException) {
+                throw new CfnAlreadyExistsException(e);
+            }
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/DeleteHandler.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/DeleteHandler.java
@@ -59,7 +59,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(describeRequest, iotClient::describeCustomMetric);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             // If the resource doesn't exist, DescribeCustomMetric will throw ResourceNotFoundException,
             // and we'll return FAILED with HandlerErrorCode.NotFound.
             // CFN (the caller) will swallow the "failure" and the customer will see success.
@@ -73,7 +73,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(deleteRequest, iotClient::deleteCustomMetric);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/ListHandler.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/ListHandler.java
@@ -35,7 +35,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
         try {
             listCustomMetricsResponse = proxy.injectCredentialsAndInvokeV2(
                     listRequest, iotClient::listCustomMetrics);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(request.getDesiredResourceState(), e, logger);
         }
 

--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/ReadHandler.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/ReadHandler.java
@@ -37,7 +37,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         try {
             describeCustomMetricResponse = proxy.injectCredentialsAndInvokeV2(
                     describeRequest, iotClient::describeCustomMetric);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/UpdateHandler.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/UpdateHandler.java
@@ -45,14 +45,14 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         String resourceArn;
         try {
             resourceArn = updateCustomMetric(proxy, desiredModel, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(desiredModel, e, logger);
         }
 
         // For an exiting resource, we have to update via TagResource API, UpdateCustomMetric API doesn't take tags.
         try {
             updateTags(proxy, request, resourceArn, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(desiredModel, e, logger);
         }
 

--- a/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/CreateHandlerTest.java
+++ b/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/CreateHandlerTest.java
@@ -11,8 +11,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.iot.model.CreateCustomMetricRequest;
 import software.amazon.awssdk.services.iot.model.CreateCustomMetricResponse;
 import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -28,6 +28,7 @@ import static com.amazonaws.iot.custommetric.TestConstants.MODEL_TAGS;
 import static com.amazonaws.iot.custommetric.TestConstants.SDK_MODEL_TAG;
 import static com.amazonaws.iot.custommetric.TestConstants.SDK_SYSTEM_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -129,9 +130,9 @@ public class CreateHandlerTest {
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))
                 .thenThrow(ResourceAlreadyExistsException.builder().build());
 
-        ProgressEvent<ResourceModel, CallbackContext> progressEvent =
-                handler.handleRequest(proxy, request, null, logger);
-        assertThat(progressEvent.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+        assertThatThrownBy(() ->
+                handler.handleRequest(proxy, request, null, logger))
+                .isInstanceOf(CfnAlreadyExistsException.class);
     }
 
     @Test

--- a/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/HandlerUtilsTest.java
+++ b/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/HandlerUtilsTest.java
@@ -22,8 +22,8 @@ import static com.amazonaws.iot.custommetric.TestConstants.SDK_MODEL_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class HandlerUtilsTest {
@@ -57,8 +57,7 @@ public class HandlerUtilsTest {
                 .tags(SDK_MODEL_TAG)
                 .nextToken("testToken")
                 .build();
-        when(proxy.injectCredentialsAndInvokeV2(eq(expectedRequest1), any()))
-                .thenReturn(listTagsForResourceResponse1);
+        doReturn(listTagsForResourceResponse1).when(proxy).injectCredentialsAndInvokeV2(eq(expectedRequest1), any());
 
         ListTagsForResourceRequest expectedRequest2 = ListTagsForResourceRequest.builder()
                 .resourceArn(CUSTOM_METRIC_ARN)
@@ -68,8 +67,7 @@ public class HandlerUtilsTest {
         ListTagsForResourceResponse listTagsForResourceResponse2 = ListTagsForResourceResponse.builder()
                 .tags(tag2)
                 .build();
-        when(proxy.injectCredentialsAndInvokeV2(eq(expectedRequest2), any()))
-                .thenReturn(listTagsForResourceResponse2);
+        doReturn(listTagsForResourceResponse2).when(proxy).injectCredentialsAndInvokeV2(eq(expectedRequest2), any());
 
         List<Tag> currentTags = HandlerUtils.listTags(iotClient, proxy, CUSTOM_METRIC_ARN, logger);
         assertThat(currentTags).isEqualTo(Arrays.asList(SDK_MODEL_TAG, tag2));

--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/CreateHandler.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/CreateHandler.java
@@ -1,17 +1,19 @@
 package com.amazonaws.iot.dimension;
 
-import java.util.Map;
-
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.CreateDimensionRequest;
 import software.amazon.awssdk.services.iot.model.CreateDimensionResponse;
+import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
+
+import java.util.Map;
 
 public class CreateHandler extends BaseHandler<CallbackContext> {
 
@@ -46,6 +48,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             createDimensionResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createDimension);
         } catch (Exception e) {
+            if (e instanceof ResourceAlreadyExistsException) {
+                throw new CfnAlreadyExistsException(e);
+            }
             return Translator.translateExceptionToErrorCode(model, e, logger);
         }
 

--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/CreateHandler.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/CreateHandler.java
@@ -47,10 +47,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         try {
             createDimensionResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createDimension);
-        } catch (Exception e) {
-            if (e instanceof ResourceAlreadyExistsException) {
-                throw new CfnAlreadyExistsException(e);
-            }
+        } catch (ResourceAlreadyExistsException e) {
+            logger.log(String.format("Resource already exists %s.", model.getName()));
+            throw new CfnAlreadyExistsException(e);
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToErrorCode(model, e, logger);
         }
 

--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/DeleteHandler.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/DeleteHandler.java
@@ -58,7 +58,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(describeRequest, iotClient::describeDimension);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             // If the resource doesn't exist, DescribeDimension will throw NotFoundException,
             // which we'll translate to NotFound Failure - that's all we need to do.
             // CFN (the caller) will swallow this failure and the customer will see success.
@@ -72,7 +72,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(deleteRequest, iotClient::deleteDimension);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToErrorCode(model, e, logger);
         }
 

--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/ListHandler.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/ListHandler.java
@@ -36,7 +36,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
         try {
             listDimensionsResponse = proxy.injectCredentialsAndInvokeV2(
                     listRequest, iotClient::listDimensions);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToErrorCode(request.getDesiredResourceState(), e, logger);
         }
 

--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/ReadHandler.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/ReadHandler.java
@@ -41,7 +41,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         try {
             describeDimensionResponse = proxy.injectCredentialsAndInvokeV2(
                     describeRequest, iotClient::describeDimension);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToErrorCode(model, e, logger);
         }
 
@@ -52,7 +52,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         List<software.amazon.awssdk.services.iot.model.Tag> iotTags;
         try {
             iotTags = listTags(proxy, dimensionArn, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToErrorCode(model, e, logger);
         }
         logger.log(String.format("Called ListTags for %s.", dimensionArn));

--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/UpdateHandler.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/UpdateHandler.java
@@ -52,7 +52,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         try {
             updateDimensionResponse =
                     proxy.injectCredentialsAndInvokeV2(updateDimensionRequest, iotClient::updateDimension);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToErrorCode(desiredModel, e, logger);
         }
         String resourceArn = updateDimensionResponse.arn();
@@ -61,7 +61,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // For an exiting resource, we have to update via TagResource API, UpdateDimension API doesn't take tags.
         try {
             updateTags(proxy, request, resourceArn, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToErrorCode(desiredModel, e, logger);
         }
 

--- a/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/CreateHandlerTest.java
+++ b/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/CreateHandlerTest.java
@@ -1,21 +1,5 @@
 package com.amazonaws.iot.dimension;
 
-import static com.amazonaws.iot.dimension.TestConstants.CLIENT_REQUEST_TOKEN;
-import static com.amazonaws.iot.dimension.TestConstants.DESIRED_TAGS;
-import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_ARN;
-import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_NAME;
-import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_TYPE;
-import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_VALUE_CFN;
-import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_VALUE_IOT;
-import static com.amazonaws.iot.dimension.TestConstants.MODEL_TAGS;
-import static com.amazonaws.iot.dimension.TestConstants.SDK_MODEL_TAG;
-import static com.amazonaws.iot.dimension.TestConstants.SDK_SYSTEM_TAG;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,12 +11,29 @@ import software.amazon.awssdk.services.iot.model.CreateDimensionRequest;
 import software.amazon.awssdk.services.iot.model.CreateDimensionResponse;
 import software.amazon.awssdk.services.iot.model.DimensionType;
 import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import static com.amazonaws.iot.dimension.TestConstants.CLIENT_REQUEST_TOKEN;
+import static com.amazonaws.iot.dimension.TestConstants.DESIRED_TAGS;
+import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_ARN;
+import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_NAME;
+import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_TYPE;
+import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_VALUE_CFN;
+import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_VALUE_IOT;
+import static com.amazonaws.iot.dimension.TestConstants.MODEL_TAGS;
+import static com.amazonaws.iot.dimension.TestConstants.SDK_MODEL_TAG;
+import static com.amazonaws.iot.dimension.TestConstants.SDK_SYSTEM_TAG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest {
@@ -123,9 +124,9 @@ public class CreateHandlerTest {
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))
                 .thenThrow(ResourceAlreadyExistsException.builder().build());
 
-        ProgressEvent<ResourceModel, CallbackContext> progressEvent =
-                handler.handleRequest(proxy, request, null, logger);
-        assertThat(progressEvent.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+        assertThatThrownBy(() ->
+                handler.handleRequest(proxy, request, null, logger))
+                .isInstanceOf(CfnAlreadyExistsException.class);
     }
 
     @Test
@@ -144,7 +145,7 @@ public class CreateHandlerTest {
                 .clientRequestToken("MyToken")
                 .desiredResourceTags(DESIRED_TAGS)
                 .stackId("arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack-name/" +
-                         "084c0bd1-082b-11eb-afdc-0a2fadfa68a5")
+                        "084c0bd1-082b-11eb-afdc-0a2fadfa68a5")
                 .build();
 
         CreateDimensionResponse createApiResponse = CreateDimensionResponse.builder()

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/CreateHandler.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/CreateHandler.java
@@ -57,10 +57,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         try {
             createMitigationActionResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createMitigationAction);
-        } catch (Exception e) {
-            if (e instanceof ResourceAlreadyExistsException) {
-                throw new CfnAlreadyExistsException(e);
-            }
+        } catch (ResourceAlreadyExistsException e) {
+            logger.log(String.format("Resource already exists %s.", model.getActionName()));
+            throw new CfnAlreadyExistsException(e);
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/CreateHandler.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/CreateHandler.java
@@ -5,6 +5,8 @@ import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.CreateMitigationActionRequest;
 import software.amazon.awssdk.services.iot.model.CreateMitigationActionResponse;
 import software.amazon.awssdk.services.iot.model.MitigationActionParams;
+import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -56,6 +58,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             createMitigationActionResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createMitigationAction);
         } catch (Exception e) {
+            if (e instanceof ResourceAlreadyExistsException) {
+                throw new CfnAlreadyExistsException(e);
+            }
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/DeleteHandler.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/DeleteHandler.java
@@ -57,7 +57,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(describeRequest, iotClient::describeMitigationAction);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             // If the resource doesn't exist, DescribeMitigationAction will throw ResourceNotFoundException,
             // and we'll return FAILED with HandlerErrorCode.NotFound.
             // CFN (the caller) will swallow the "failure" and the customer will see success.
@@ -71,7 +71,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(deleteRequest, iotClient::deleteMitigationAction);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/ListHandler.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/ListHandler.java
@@ -35,7 +35,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
         try {
             listMitigationActionsResponse = proxy.injectCredentialsAndInvokeV2(
                     listRequest, iotClient::listMitigationActions);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(request.getDesiredResourceState(), e, logger);
         }
 

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/ReadHandler.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/ReadHandler.java
@@ -37,7 +37,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         try {
             describeMitigationActionResponse = proxy.injectCredentialsAndInvokeV2(
                     describeRequest, iotClient::describeMitigationAction);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/UpdateHandler.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/UpdateHandler.java
@@ -52,14 +52,14 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         String resourceArn;
         try {
             resourceArn = updateMitigationAction(proxy, desiredModel, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(desiredModel, e, logger);
         }
 
         // For an exiting resource, we have to update via TagResource API, UpdateMitigationId API doesn't take tags.
         try {
             updateTags(proxy, request, resourceArn, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(desiredModel, e, logger);
         }
 

--- a/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/CreateHandlerTest.java
+++ b/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/CreateHandlerTest.java
@@ -11,8 +11,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.iot.model.CreateMitigationActionRequest;
 import software.amazon.awssdk.services.iot.model.CreateMitigationActionResponse;
 import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -30,6 +30,7 @@ import static com.amazonaws.iot.mitigationaction.TestConstants.SDK_ACTION_PARAMS
 import static com.amazonaws.iot.mitigationaction.TestConstants.SDK_MODEL_TAG;
 import static com.amazonaws.iot.mitigationaction.TestConstants.SDK_SYSTEM_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -131,9 +132,9 @@ public class CreateHandlerTest {
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))
                 .thenThrow(ResourceAlreadyExistsException.builder().build());
 
-        ProgressEvent<ResourceModel, CallbackContext> progressEvent =
-                handler.handleRequest(proxy, request, null, logger);
-        assertThat(progressEvent.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+        assertThatThrownBy(() ->
+                handler.handleRequest(proxy, request, null, logger))
+                .isInstanceOf(CfnAlreadyExistsException.class);
     }
 
     @Test

--- a/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/HandlerUtilsTest.java
+++ b/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/HandlerUtilsTest.java
@@ -22,8 +22,8 @@ import static com.amazonaws.iot.mitigationaction.TestConstants.SDK_MODEL_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class HandlerUtilsTest {
@@ -57,8 +57,7 @@ public class HandlerUtilsTest {
                 .tags(SDK_MODEL_TAG)
                 .nextToken("testToken")
                 .build();
-        when(proxy.injectCredentialsAndInvokeV2(eq(expectedRequest1), any()))
-                .thenReturn(listTagsForResourceResponse1);
+        doReturn(listTagsForResourceResponse1).when(proxy).injectCredentialsAndInvokeV2(eq(expectedRequest1), any());
 
         ListTagsForResourceRequest expectedRequest2 = ListTagsForResourceRequest.builder()
                 .resourceArn(ACTION_ARN)
@@ -68,8 +67,7 @@ public class HandlerUtilsTest {
         ListTagsForResourceResponse listTagsForResourceResponse2 = ListTagsForResourceResponse.builder()
                 .tags(tag2)
                 .build();
-        when(proxy.injectCredentialsAndInvokeV2(eq(expectedRequest2), any()))
-                .thenReturn(listTagsForResourceResponse2);
+        doReturn(listTagsForResourceResponse2).when(proxy).injectCredentialsAndInvokeV2(eq(expectedRequest2), any());
 
         List<Tag> currentTags = HandlerUtils.listTags(iotClient, proxy, ACTION_ARN, logger);
         assertThat(currentTags).isEqualTo(Arrays.asList(SDK_MODEL_TAG, tag2));

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/CreateHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/CreateHandler.java
@@ -48,10 +48,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         try {
             createScheduledAuditResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createScheduledAudit);
-        } catch (Exception e) {
-            if (e instanceof ResourceAlreadyExistsException) {
-                throw new CfnAlreadyExistsException(e);
-            }
+        } catch (ResourceAlreadyExistsException e) {
+            logger.log(String.format("Resource already exists %s.", model.getScheduledAuditName()));
+            throw new CfnAlreadyExistsException(e);
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/CreateHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/CreateHandler.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.CreateScheduledAuditRequest;
 import software.amazon.awssdk.services.iot.model.CreateScheduledAuditResponse;
+import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -47,6 +49,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             createScheduledAuditResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createScheduledAudit);
         } catch (Exception e) {
+            if (e instanceof ResourceAlreadyExistsException) {
+                throw new CfnAlreadyExistsException(e);
+            }
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/DeleteHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/DeleteHandler.java
@@ -58,7 +58,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(deleteRequest, iotClient::deleteScheduledAudit);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/ListHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/ListHandler.java
@@ -35,7 +35,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
         try {
             listScheduledAuditsResponse = proxy.injectCredentialsAndInvokeV2(
                     listRequest, iotClient::listScheduledAudits);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(request.getDesiredResourceState(), e, logger);
         }
 

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/ReadHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/ReadHandler.java
@@ -38,7 +38,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         try {
             describeScheduledAuditResponse = proxy.injectCredentialsAndInvokeV2(
                     describeRequest, iotClient::describeScheduledAudit);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/UpdateHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/UpdateHandler.java
@@ -45,14 +45,14 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         String resourceArn;
         try {
             resourceArn = updateScheduledAudit(proxy, desiredModel, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(desiredModel, e, logger);
         }
 
         // For an exiting resource, we have to update via TagResource API, UpdateScheduledAudit API doesn't take tags.
         try {
             updateTags(proxy, request, resourceArn, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(desiredModel, e, logger);
         }
 

--- a/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/CreateHandlerTest.java
+++ b/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/CreateHandlerTest.java
@@ -10,8 +10,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.iot.model.CreateScheduledAuditRequest;
 import software.amazon.awssdk.services.iot.model.CreateScheduledAuditResponse;
 import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -28,6 +28,7 @@ import static com.amazonaws.iot.scheduledaudit.TestConstants.SDK_MODEL_TAG;
 import static com.amazonaws.iot.scheduledaudit.TestConstants.SDK_SYSTEM_TAG;
 import static com.amazonaws.iot.scheduledaudit.TestConstants.TARGET_CHECK_NAMES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -125,9 +126,9 @@ public class CreateHandlerTest {
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))
                 .thenThrow(ResourceAlreadyExistsException.builder().build());
 
-        ProgressEvent<ResourceModel, CallbackContext> progressEvent =
-                handler.handleRequest(proxy, request, null, logger);
-        assertThat(progressEvent.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+        assertThatThrownBy(() ->
+                handler.handleRequest(proxy, request, null, logger))
+                .isInstanceOf(CfnAlreadyExistsException.class);
     }
 
     @Test

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/CreateHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/CreateHandler.java
@@ -51,10 +51,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         try {
             createResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createSecurityProfile);
-        } catch (Exception e) {
-            if (e instanceof ResourceAlreadyExistsException) {
-                throw new CfnAlreadyExistsException(e);
-            }
+        } catch (ResourceAlreadyExistsException e) {
+            logger.log(String.format("Resource already exists %s.", model.getSecurityProfileName()));
+            throw new CfnAlreadyExistsException(e);
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 
@@ -76,7 +76,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                         .build();
                 try {
                     proxy.injectCredentialsAndInvokeV2(attachRequest, iotClient::attachSecurityProfile);
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     return Translator.translateExceptionToProgressEvent(model, e, logger);
                 }
                 logger.log("Attached the security profile to " + targetArn);

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/CreateHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/CreateHandler.java
@@ -1,21 +1,22 @@
 package com.amazonaws.iot.securityprofile;
 
-import java.util.Map;
-import java.util.Set;
-
 import com.google.common.util.concurrent.RateLimiter;
-
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.AttachSecurityProfileRequest;
 import software.amazon.awssdk.services.iot.model.CreateSecurityProfileRequest;
 import software.amazon.awssdk.services.iot.model.CreateSecurityProfileResponse;
+import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
+
+import java.util.Map;
+import java.util.Set;
 
 public class CreateHandler extends BaseHandler<CallbackContext> {
 
@@ -51,6 +52,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             createResponse = proxy.injectCredentialsAndInvokeV2(
                     createRequest, iotClient::createSecurityProfile);
         } catch (Exception e) {
+            if (e instanceof ResourceAlreadyExistsException) {
+                throw new CfnAlreadyExistsException(e);
+            }
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/DeleteHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/DeleteHandler.java
@@ -55,7 +55,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(describeRequest, iotClient::describeSecurityProfile);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             // If the resource doesn't exist, DescribeSecurityProfile will throw NotFoundException,
             // and we'll return FAILED with HandlerErrorCode.NotFound.
             // CFN (the caller) will swallow the "failure" and the customer will see success.
@@ -69,7 +69,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .build();
         try {
             proxy.injectCredentialsAndInvokeV2(deleteRequest, iotClient::deleteSecurityProfile);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/ListHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/ListHandler.java
@@ -35,7 +35,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
         try {
             listSecurityProfilesResponse = proxy.injectCredentialsAndInvokeV2(
                     listRequest, iotClient::listSecurityProfiles);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(request.getDesiredResourceState(), e, logger);
         }
 

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/ReadHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/ReadHandler.java
@@ -37,7 +37,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         try {
             describeResponse = proxy.injectCredentialsAndInvokeV2(
                     describeRequest, iotClient::describeSecurityProfile);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(model, e, logger);
         }
 

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/UpdateHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/UpdateHandler.java
@@ -54,21 +54,21 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         String securityProfileArn;
         try {
             securityProfileArn = updateSecurityProfile(proxy, desiredModel, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(desiredModel, e, logger);
         }
 
         // Security profile targets are managed by separate APIs, not UpdateSecurityProfile.
         try {
             updateTargetAttachments(proxy, desiredModel, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(desiredModel, e, logger);
         }
 
         // Same for tags.
         try {
             updateTags(proxy, request, securityProfileArn, logger);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Translator.translateExceptionToProgressEvent(desiredModel, e, logger);
         }
 

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/CreateHandlerTest.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/CreateHandlerTest.java
@@ -1,23 +1,5 @@
 package com.amazonaws.iot.securityprofile;
 
-import static com.amazonaws.iot.securityprofile.TestConstants.ADDITIONAL_METRICS_CFN;
-import static com.amazonaws.iot.securityprofile.TestConstants.ADDITIONAL_METRICS_IOT;
-import static com.amazonaws.iot.securityprofile.TestConstants.CLIENT_REQUEST_TOKEN;
-import static com.amazonaws.iot.securityprofile.TestConstants.LOGICAL_IDENTIFIER;
-import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_ARN;
-import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_NAME;
-import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_CFN_SET;
-import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_IOT;
-import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_STRINGMAP;
-import static com.amazonaws.iot.securityprofile.TestConstants.TARGET_ARNS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -30,12 +12,32 @@ import software.amazon.awssdk.services.iot.model.CreateSecurityProfileResponse;
 import software.amazon.awssdk.services.iot.model.IotRequest;
 import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
 import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.List;
+
+import static com.amazonaws.iot.securityprofile.TestConstants.ADDITIONAL_METRICS_CFN;
+import static com.amazonaws.iot.securityprofile.TestConstants.ADDITIONAL_METRICS_IOT;
+import static com.amazonaws.iot.securityprofile.TestConstants.CLIENT_REQUEST_TOKEN;
+import static com.amazonaws.iot.securityprofile.TestConstants.LOGICAL_IDENTIFIER;
+import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_ARN;
+import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_NAME;
+import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_CFN_SET;
+import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_IOT;
+import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_STRINGMAP;
+import static com.amazonaws.iot.securityprofile.TestConstants.TARGET_ARNS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CreateHandlerTest {
 
@@ -130,9 +132,9 @@ public class CreateHandlerTest {
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))
                 .thenThrow(ResourceAlreadyExistsException.builder().build());
 
-        ProgressEvent<ResourceModel, CallbackContext> progressEvent =
-                handler.handleRequest(proxy, request, null, logger);
-        assertThat(progressEvent.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+        assertThatThrownBy(() ->
+                handler.handleRequest(proxy, request, null, logger))
+                .isInstanceOf(CfnAlreadyExistsException.class);
     }
 
     @Test
@@ -176,7 +178,7 @@ public class CreateHandlerTest {
                 .clientRequestToken("MyToken")
                 .desiredResourceTags(TAG_1_STRINGMAP)
                 .stackId("arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack-name/" +
-                         "084c0bd1-082b-11eb-afdc-0a2fadfa68a5")
+                        "084c0bd1-082b-11eb-afdc-0a2fadfa68a5")
                 .build();
 
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))


### PR DESCRIPTION
…er minor fixes

If the resource we are trying to create already exists out of band, CFN deletes the resource as part of rollback of the stack. The delete succeeds with progress even object because it has the physical id of the resource. As a workaround switching back to throwing a CfnAlreadyExistsException as in this case CFN does not have the physical id and the delete does not go through. 
Tested the change with integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
