### PR TITLE
Add support for system tags in Device Defender resources

### DIFF
--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/CreateHandler.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/CreateHandler.java
@@ -13,6 +13,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class CreateHandler extends BaseHandler<CallbackContext> {
@@ -73,18 +74,24 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                     request.getClientRequestToken(), GENERATED_NAME_MAX_LENGTH));
         }
 
-        // getDesiredResourceTags combines the model and stack-level tags.
-        // Reference: https://tinyurl.com/yyxtd7w6
-        Map<String, String> tags = request.getDesiredResourceTags();
-        // TODO: uncomment this after we update the service to allow these (only from CFN)
-        // SystemTags are the default stack-level tags with aws:cloudformation prefix
-        // tags.putAll(request.getSystemTags());
+        // Combine all tags in one map that we'll use for the request
+        Map<String, String> allTags = new HashMap<>();
+        if (request.getDesiredResourceTags() != null) {
+            // DesiredResourceTags includes both model and stack-level tags.
+            // Reference: https://tinyurl.com/yyxtd7w6
+            allTags.putAll(request.getDesiredResourceTags());
+        }
+        if (request.getSystemTags() != null) {
+            // There are also system tags provided separately.
+            // SystemTags are the default stack-level tags with aws:cloudformation prefix
+            allTags.putAll(request.getSystemTags());
+        }
 
         return CreateCustomMetricRequest.builder()
                 .metricName(model.getMetricName())
                 .displayName(model.getDisplayName())
                 .metricType(model.getMetricType())
-                .tags(Translator.translateTagsToSdk(tags))
+                .tags(Translator.translateTagsToSdk(allTags))
                 // Note: using CFN's token here. Motivation: suppose CFN calls this handler, create call succeeds,
                 // but the handler dies right before returning success. Then CFN retries. The retry will contain the
                 // same token. If we don't set the clientRequestToken, the Create

--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/CreateHandler.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/CreateHandler.java
@@ -34,7 +34,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             CallbackContext callbackContext,
             Logger logger) {
 
-        CreateCustomMetricRequest createRequest = translateToCreateRequest(request);
+        CreateCustomMetricRequest createRequest = translateToCreateRequest(request, logger);
 
         ResourceModel model = request.getDesiredResourceState();
         if (!StringUtils.isEmpty(model.getMetricArn())) {
@@ -62,7 +62,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         return ProgressEvent.defaultSuccessHandler(model);
     }
 
-    private CreateCustomMetricRequest translateToCreateRequest(ResourceHandlerRequest<ResourceModel> request) {
+    private CreateCustomMetricRequest translateToCreateRequest(
+            ResourceHandlerRequest<ResourceModel> request,
+            Logger logger) {
 
         ResourceModel model = request.getDesiredResourceState();
 
@@ -85,6 +87,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             // There are also system tags provided separately.
             // SystemTags are the default stack-level tags with aws:cloudformation prefix
             allTags.putAll(request.getSystemTags());
+        } else {
+            // System tags should always be present as long as the Handler is called by CloudFormation
+            logger.log("Unexpectedly, system tags are null in the create request for " +
+                       ResourceModel.TYPE_NAME + " " + model.getMetricName());
         }
 
         return CreateCustomMetricRequest.builder()

--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/UpdateHandler.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/UpdateHandler.java
@@ -14,8 +14,10 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -37,7 +39,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         ResourceModel desiredModel = request.getDesiredResourceState();
         String desiredArn = desiredModel.getMetricArn();
         if (!StringUtils.isEmpty(desiredArn)) {
-            logger.log(String.format("MetricArn cannot be updated, caller tried setting it to " + desiredArn));
+            logger.log("MetricArn cannot be updated, caller tried setting it to " + desiredArn);
             return ProgressEvent.failed(desiredModel, callbackContext, HandlerErrorCode.InvalidRequest,
                     "MetricArn cannot be updated.");
         }
@@ -95,12 +97,23 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // Yet we should, otherwise the resource wouldn't equate the template.
         Set<Tag> currentTags = listTags(proxy, resourceArn, logger);
 
-        // getDesiredResourceTags includes model+stack-level tags, reference: https://tinyurl.com/y2p8medk
-        Set<Tag> desiredTags = Translator.translateTagsToSdk(request.getDesiredResourceTags());
-        // TODO: uncomment this after we update the service to allow these (only from CFN)
-        // SystemTags are the default stack-level tags with aws:cloudformation prefix
-        // desiredTags.addAll(Translator.translateTagsToSdk(request.getSystemTags()));
-
+        // Combine all tags in one map that we'll use for the request
+        Map<String, String> allDesiredTagsMap = new HashMap<>();
+        if (request.getDesiredResourceTags() != null) {
+            // DesiredResourceTags includes both model and stack-level tags.
+            // Reference: https://tinyurl.com/yyxtd7w6
+            allDesiredTagsMap.putAll(request.getDesiredResourceTags());
+        }
+        if (request.getSystemTags() != null) {
+            // There are also system tags provided separately.
+            // SystemTags are the default stack-level tags with aws:cloudformation prefix.
+            allDesiredTagsMap.putAll(request.getSystemTags());
+        } else {
+            // System tags should never get updated as they are the stack id, stack name,
+            // and logical resource id.
+            logger.log("Unexpectedly, system tags are null in the update request for " + resourceArn);
+        }
+        Set<Tag> desiredTags = Translator.translateTagsToSdk(allDesiredTagsMap);
         Set<String> desiredTagKeys = desiredTags.stream()
                 .map(Tag::key)
                 .collect(Collectors.toSet());

--- a/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/TestConstants.java
+++ b/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/TestConstants.java
@@ -26,7 +26,8 @@ public class TestConstants {
                     .value("resourceTagValue")
                     .build());
     protected static final Map<String, String> DESIRED_TAGS = ImmutableMap.of(
-            "resourceTagKey", "resourceTagValue",
+            "resourceTagKey", "resourceTagValue");
+    static final Map<String, String> SYSTEM_TAG_MAP = ImmutableMap.of(
             "aws:cloudformation:stack-name", "UnitTestStack");
     protected static final software.amazon.awssdk.services.iot.model.Tag SDK_MODEL_TAG =
             software.amazon.awssdk.services.iot.model.Tag.builder()

--- a/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/UpdateHandlerTest.java
+++ b/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/UpdateHandlerTest.java
@@ -1,6 +1,8 @@
 package com.amazonaws.iot.custommetric;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +33,8 @@ import static com.amazonaws.iot.custommetric.TestConstants.CUSTOM_METRIC_NAME;
 import static com.amazonaws.iot.custommetric.TestConstants.DISPLAY_NAME;
 import static com.amazonaws.iot.custommetric.TestConstants.DISPLAY_NAME2;
 import static com.amazonaws.iot.custommetric.TestConstants.METRIC_TYPE;
+import static com.amazonaws.iot.custommetric.TestConstants.SDK_SYSTEM_TAG;
+import static com.amazonaws.iot.custommetric.TestConstants.SYSTEM_TAG_MAP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -88,9 +92,10 @@ public class UpdateHandlerTest {
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceState(desiredModel)
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(PREVIOUS_SDK_RESOURCE_TAG))
+        doReturn(ImmutableSet.of(PREVIOUS_SDK_RESOURCE_TAG, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, CUSTOM_METRIC_ARN, logger);
 
@@ -145,9 +150,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(previousTag))
+        doReturn(ImmutableSet.of(previousTag, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, CUSTOM_METRIC_ARN, logger);
 
@@ -169,9 +175,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(PREVIOUS_SDK_RESOURCE_TAG))
+        doReturn(ImmutableSet.of(PREVIOUS_SDK_RESOURCE_TAG, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, CUSTOM_METRIC_ARN, logger);
 
@@ -220,6 +227,7 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(ImmutableMap.of("DesiredTagKey", "DesiredTagValue"))
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))

--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/CreateHandler.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/CreateHandler.java
@@ -34,7 +34,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             CallbackContext callbackContext,
             Logger logger) {
 
-        CreateDimensionRequest createRequest = translateToCreateRequest(request);
+        CreateDimensionRequest createRequest = translateToCreateRequest(request, logger);
 
         ResourceModel model = request.getDesiredResourceState();
         if (!StringUtils.isEmpty(model.getArn())) {
@@ -61,7 +61,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         return ProgressEvent.defaultSuccessHandler(model);
     }
 
-    private CreateDimensionRequest translateToCreateRequest(ResourceHandlerRequest<ResourceModel> request) {
+    private CreateDimensionRequest translateToCreateRequest(
+            ResourceHandlerRequest<ResourceModel> request,
+            Logger logger) {
 
         ResourceModel model = request.getDesiredResourceState();
 
@@ -84,6 +86,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             // There are also system tags provided separately.
             // SystemTags are the default stack-level tags with aws:cloudformation prefix
             allTags.putAll(request.getSystemTags());
+        } else {
+            // System tags should always be present as long as the Handler is called by CloudFormation
+            logger.log("Unexpectedly, system tags are null in the create request for " +
+                       ResourceModel.TYPE_NAME + " " + model.getName());
         }
 
         // Note that the handlers act as pass-through in terms of input validation.

--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/UpdateHandler.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/UpdateHandler.java
@@ -1,7 +1,9 @@
 package com.amazonaws.iot.dimension;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -84,12 +86,24 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // Yet we should, otherwise the resource wouldn't equate the template.
         Set<Tag> currentTags = listTags(proxy, resourceArn, logger);
 
-        // getDesiredResourceTags includes model+stack-level tags, reference: https://tinyurl.com/y2p8medk
-        Set<Tag> desiredTags = Translator.translateTagsToSdk(request.getDesiredResourceTags());
-        // TODO: uncomment this after we update the service to allow these (only from CFN)
-        // SystemTags are the default stack-level tags with aws:cloudformation prefix
-        // desiredTags.addAll(Translator.translateTagsToSdk(request.getSystemTags()));
+        // Combine all tags in one map that we'll use for the request
+        Map<String, String> allDesiredTagsMap = new HashMap<>();
+        if (request.getDesiredResourceTags() != null) {
+            // DesiredResourceTags includes both model and stack-level tags.
+            // Reference: https://tinyurl.com/yyxtd7w6
+            allDesiredTagsMap.putAll(request.getDesiredResourceTags());
+        }
+        if (request.getSystemTags() != null) {
+            // There are also system tags provided separately.
+            // SystemTags are the default stack-level tags with aws:cloudformation prefix.
+            allDesiredTagsMap.putAll(request.getSystemTags());
+        } else {
+            // System tags should never get updated as they are the stack id, stack name,
+            // and logical resource id.
+            logger.log("Unexpectedly, system tags are null in the update request for " + resourceArn);
+        }
 
+        Set<Tag> desiredTags = Translator.translateTagsToSdk(allDesiredTagsMap);
         Set<String> desiredTagKeys = desiredTags.stream()
                 .map(Tag::key)
                 .collect(Collectors.toSet());

--- a/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/HandlerUtilsTest.java
+++ b/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/HandlerUtilsTest.java
@@ -1,7 +1,7 @@
 package com.amazonaws.iot.dimension;
 
 import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_ARN;
-import static com.amazonaws.iot.dimension.TestConstants.SDK_MODEL_TAG;
+import static com.amazonaws.iot.dimension.TestConstants.SDK_MODEL_TAG_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,7 +45,7 @@ public class HandlerUtilsTest {
                 .resourceArn(DIMENSION_ARN)
                 .build();
         ListTagsForResourceResponse listTagsForResourceResponse1 = ListTagsForResourceResponse.builder()
-                .tags(SDK_MODEL_TAG)
+                .tags(SDK_MODEL_TAG_1)
                 .nextToken("testToken")
                 .build();
         when(proxy.injectCredentialsAndInvokeV2(eq(expectedRequest1), any()))
@@ -55,7 +55,7 @@ public class HandlerUtilsTest {
                 .resourceArn(DIMENSION_ARN)
                 .nextToken("testToken")
                 .build();
-        software.amazon.awssdk.services.iot.model.Tag tag2 = SDK_MODEL_TAG.toBuilder().key("key2").build();
+        software.amazon.awssdk.services.iot.model.Tag tag2 = SDK_MODEL_TAG_1.toBuilder().key("key2").build();
         ListTagsForResourceResponse listTagsForResourceResponse2 = ListTagsForResourceResponse.builder()
                 .tags(tag2)
                 .build();
@@ -63,6 +63,6 @@ public class HandlerUtilsTest {
                 .thenReturn(listTagsForResourceResponse2);
 
         List<Tag> currentTags = HandlerUtils.listTags(iotClient, proxy, DIMENSION_ARN, logger);
-        assertThat(currentTags).isEqualTo(Arrays.asList(SDK_MODEL_TAG, tag2));
+        assertThat(currentTags).isEqualTo(Arrays.asList(SDK_MODEL_TAG_1, tag2));
     }
 }

--- a/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/ReadHandlerTest.java
+++ b/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/ReadHandlerTest.java
@@ -6,7 +6,7 @@ import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_TYPE;
 import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_VALUE_CFN;
 import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_VALUE_IOT;
 import static com.amazonaws.iot.dimension.TestConstants.MODEL_TAGS;
-import static com.amazonaws.iot.dimension.TestConstants.SDK_MODEL_TAG;
+import static com.amazonaws.iot.dimension.TestConstants.SDK_MODEL_TAG_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,7 +64,7 @@ public class ReadHandlerTest {
         when(proxy.injectCredentialsAndInvokeV2(eq(expectedDescribeRequest), any()))
                 .thenReturn(describeResponse);
 
-        doReturn(Collections.singletonList(SDK_MODEL_TAG))
+        doReturn(Collections.singletonList(SDK_MODEL_TAG_1))
                 .when(handler)
                 .listTags(proxy, DIMENSION_ARN, logger);
 

--- a/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/TestConstants.java
+++ b/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/TestConstants.java
@@ -19,20 +19,28 @@ public class TestConstants {
 
     protected static final Set<Tag> MODEL_TAGS = ImmutableSet.of(
             Tag.builder()
-                    .key("resourceTagKey")
-                    .value("resourceTagValue")
+                    .key("resourceTagKey1")
+                    .value("resourceTagValue1")
                     .build());
     protected static final Map<String, String> DESIRED_TAGS = ImmutableMap.of(
-            "resourceTagKey", "resourceTagValue",
-            "aws:cloudformation:stack-name", "UnitTestStack");
-    protected static final software.amazon.awssdk.services.iot.model.Tag SDK_MODEL_TAG =
+            "resourceTagKey1", "resourceTagValue1",
+            "resourceTagKey2", "resourceTagValue2");
+    protected static final software.amazon.awssdk.services.iot.model.Tag SDK_MODEL_TAG_1 =
             software.amazon.awssdk.services.iot.model.Tag.builder()
-                    .key("resourceTagKey")
-                    .value("resourceTagValue")
+                    .key("resourceTagKey1")
+                    .value("resourceTagValue1")
                     .build();
+    protected static final software.amazon.awssdk.services.iot.model.Tag SDK_MODEL_TAG_2 =
+            software.amazon.awssdk.services.iot.model.Tag.builder()
+                    .key("resourceTagKey2")
+                    .value("resourceTagValue2")
+                    .build();
+    protected static final Map<String, String> SYSTEM_TAG_MAP = ImmutableMap.of(
+            "aws:cloudformation:stack-name", "UnitTestStack");
     protected static final software.amazon.awssdk.services.iot.model.Tag SDK_SYSTEM_TAG =
             software.amazon.awssdk.services.iot.model.Tag.builder()
                     .key("aws:cloudformation:stack-name")
                     .value("UnitTestStack")
                     .build();
+
 }

--- a/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/UpdateHandlerTest.java
+++ b/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/UpdateHandlerTest.java
@@ -5,6 +5,8 @@ import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_NAME;
 import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_TYPE;
 import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_VALUE_CFN;
 import static com.amazonaws.iot.dimension.TestConstants.DIMENSION_VALUE_IOT;
+import static com.amazonaws.iot.dimension.TestConstants.SDK_SYSTEM_TAG;
+import static com.amazonaws.iot.dimension.TestConstants.SYSTEM_TAG_MAP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,9 +37,6 @@ import software.amazon.awssdk.services.iot.model.TagResourceRequest;
 import software.amazon.awssdk.services.iot.model.UntagResourceRequest;
 import software.amazon.awssdk.services.iot.model.UpdateDimensionRequest;
 import software.amazon.awssdk.services.iot.model.UpdateDimensionResponse;
-import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -90,9 +89,10 @@ public class UpdateHandlerTest {
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceState(desiredModel)
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(PREVIOUS_SDK_RESOURCE_TAG))
+        doReturn(ImmutableSet.of(PREVIOUS_SDK_RESOURCE_TAG, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, DIMENSION_ARN, logger);
 
@@ -145,9 +145,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(previousTag))
+        doReturn(ImmutableSet.of(previousTag, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, DIMENSION_ARN, logger);
 
@@ -168,9 +169,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(PREVIOUS_SDK_RESOURCE_TAG))
+        doReturn(ImmutableSet.of(PREVIOUS_SDK_RESOURCE_TAG, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, DIMENSION_ARN, logger);
 
@@ -201,6 +203,7 @@ public class UpdateHandlerTest {
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .previousResourceState(previousModel)
                 .desiredResourceState(desiredModel)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))
@@ -218,6 +221,7 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(ImmutableMap.of("DesiredTagKey", "DesiredTagValue"))
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))
@@ -247,6 +251,7 @@ public class UpdateHandlerTest {
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .previousResourceState(previousModel)
                 .desiredResourceState(desiredModel)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         // If the resource is already deleted, the update API throws ResourceNotFoundException. Mocking that here.
@@ -277,6 +282,7 @@ public class UpdateHandlerTest {
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .previousResourceState(previousModel)
                 .desiredResourceState(desiredModel)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         ProgressEvent<ResourceModel, CallbackContext> result =
@@ -285,6 +291,4 @@ public class UpdateHandlerTest {
         assertThat(result).isEqualTo(ProgressEvent.failed(
                 desiredModel, null, HandlerErrorCode.InvalidRequest, "Arn cannot be updated."));
     }
-
-    // TODO: test system tags when the src code is ready
 }

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/CreateHandler.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/CreateHandler.java
@@ -1,5 +1,8 @@
 package com.amazonaws.iot.mitigationaction;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.iot.IotClient;
 import software.amazon.awssdk.services.iot.model.CreateMitigationActionRequest;
@@ -13,8 +16,6 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
-
-import java.util.Map;
 
 public class CreateHandler extends BaseHandler<CallbackContext> {
 
@@ -84,12 +85,19 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                     request.getClientRequestToken(), GENERATED_NAME_MAX_LENGTH));
         }
 
-        // getDesiredResourceTags combines the model and stack-level tags.
-        // Reference: https://tinyurl.com/yyxtd7w6
-        Map<String, String> tags = request.getDesiredResourceTags();
-        // TODO: uncomment this after we update the service to allow these (only from CFN)
-        // SystemTags are the default stack-level tags with aws:cloudformation prefix
-        // tags.putAll(request.getSystemTags());
+        // Combine all tags in one map that we'll use for the request
+        Map<String, String> allTags = new HashMap<>();
+        if (request.getDesiredResourceTags() != null) {
+            // DesiredResourceTags includes both model and stack-level tags.
+            // Reference: https://tinyurl.com/yyxtd7w6
+            allTags.putAll(request.getDesiredResourceTags());
+        }
+        if (request.getSystemTags() != null) {
+            // There are also system tags provided separately.
+            // SystemTags are the default stack-level tags with aws:cloudformation prefix
+            allTags.putAll(request.getSystemTags());
+        }
+
         MitigationActionParams actionParams = Translator.translateActionParamsToSdk(model.getActionParams());
 
         // Note that the handlers act as pass-through in terms of input validation.
@@ -99,7 +107,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 .actionName(model.getActionName())
                 .roleArn(model.getRoleArn())
                 .actionParams(actionParams)
-                .tags(Translator.translateTagsToSdk(tags))
+                .tags(Translator.translateTagsToSdk(allTags))
                 .build();
     }
 }

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/CreateHandler.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/CreateHandler.java
@@ -35,7 +35,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             CallbackContext callbackContext,
             Logger logger) {
 
-        CreateMitigationActionRequest createRequest = translateToCreateRequest(request);
+        CreateMitigationActionRequest createRequest = translateToCreateRequest(request, logger);
 
         ResourceModel model = request.getDesiredResourceState();
         if (!StringUtils.isEmpty(model.getMitigationActionArn())) {
@@ -73,7 +73,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         return ProgressEvent.defaultSuccessHandler(model);
     }
 
-    private static CreateMitigationActionRequest translateToCreateRequest(ResourceHandlerRequest<ResourceModel> request) {
+    private static CreateMitigationActionRequest translateToCreateRequest(
+            ResourceHandlerRequest<ResourceModel> request,
+            Logger logger) {
 
         ResourceModel model = request.getDesiredResourceState();
 
@@ -96,6 +98,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             // There are also system tags provided separately.
             // SystemTags are the default stack-level tags with aws:cloudformation prefix
             allTags.putAll(request.getSystemTags());
+        } else {
+            // System tags should always be present as long as the Handler is called by CloudFormation
+            logger.log("Unexpectedly, system tags are null in the create request for " +
+                       ResourceModel.TYPE_NAME + " " + model.getActionName());
         }
 
         MitigationActionParams actionParams = Translator.translateActionParamsToSdk(model.getActionParams());

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/UpdateHandler.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/UpdateHandler.java
@@ -14,8 +14,10 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -37,14 +39,14 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         ResourceModel desiredModel = request.getDesiredResourceState();
         String desiredArn = desiredModel.getMitigationActionArn();
         if (!StringUtils.isEmpty(desiredArn)) {
-            logger.log(String.format("MitigationActionArn cannot be updated, caller tried setting it to " + desiredArn));
+            logger.log("MitigationActionArn cannot be updated, caller tried setting it to " + desiredArn);
             return ProgressEvent.failed(desiredModel, callbackContext, HandlerErrorCode.InvalidRequest,
                     "MitigationActionArn cannot be updated.");
         }
 
         String desiredActionId = desiredModel.getMitigationActionId();
         if (!StringUtils.isEmpty(desiredActionId)) {
-            logger.log(String.format("MitigationActionId cannot be updated, caller tried setting it to " + desiredActionId));
+            logger.log("MitigationActionId cannot be updated, caller tried setting it to " + desiredActionId);
             return ProgressEvent.failed(desiredModel, callbackContext, HandlerErrorCode.InvalidRequest,
                     "MitigationActionId cannot be updated.");
         }
@@ -101,12 +103,24 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // Yet we should, otherwise the resource wouldn't equate the template.
         Set<Tag> currentTags = listTags(proxy, resourceArn, logger);
 
-        // getDesiredResourceTags includes model+stack-level tags, reference: https://tinyurl.com/y55mqrnc
-        Set<Tag> desiredTags = Translator.translateTagsToSdk(request.getDesiredResourceTags());
-        // TODO: uncomment this after we update the service to allow these (only from CFN)
-        // SystemTags are the default stack-level tags with aws:cloudformation prefix
-        // desiredTags.addAll(Translator.translateTagsToSdk(request.getSystemTags()));
+        // Combine all tags in one map that we'll use for the request
+        Map<String, String> allDesiredTagsMap = new HashMap<>();
+        if (request.getDesiredResourceTags() != null) {
+            // DesiredResourceTags includes both model and stack-level tags.
+            // Reference: https://tinyurl.com/yyxtd7w6
+            allDesiredTagsMap.putAll(request.getDesiredResourceTags());
+        }
+        if (request.getSystemTags() != null) {
+            // There are also system tags provided separately.
+            // SystemTags are the default stack-level tags with aws:cloudformation prefix.
+            allDesiredTagsMap.putAll(request.getSystemTags());
+        } else {
+            // System tags should never get updated as they are the stack id, stack name,
+            // and logical resource id.
+            logger.log("Unexpectedly, system tags are null in the update request for " + resourceArn);
+        }
 
+        Set<Tag> desiredTags = Translator.translateTagsToSdk(allDesiredTagsMap);
         Set<String> desiredTagKeys = desiredTags.stream()
                 .map(Tag::key)
                 .collect(Collectors.toSet());

--- a/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/TestConstants.java
+++ b/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/TestConstants.java
@@ -149,6 +149,8 @@ public class TestConstants {
     protected static final Map<String, String> DESIRED_TAGS = ImmutableMap.of(
             "resourceTagKey", "resourceTagValue",
             "aws:cloudformation:stack-name", "UnitTestStack");
+    static final Map<String, String> SYSTEM_TAG_MAP = ImmutableMap.of(
+            "aws:cloudformation:stack-name", "UnitTestStack");
     protected static final software.amazon.awssdk.services.iot.model.Tag SDK_MODEL_TAG =
             software.amazon.awssdk.services.iot.model.Tag.builder()
                     .key("resourceTagKey")

--- a/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/UpdateHandlerTest.java
+++ b/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/UpdateHandlerTest.java
@@ -1,6 +1,8 @@
 package com.amazonaws.iot.mitigationaction;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +36,8 @@ import static com.amazonaws.iot.mitigationaction.TestConstants.ACTION_PARAMS_WIT
 import static com.amazonaws.iot.mitigationaction.TestConstants.MITIGATION_ACTION_NAME;
 import static com.amazonaws.iot.mitigationaction.TestConstants.MITIGATION_ACTION_ROLE_ARN;
 import static com.amazonaws.iot.mitigationaction.TestConstants.SDK_ACTION_PARAMS_WITH_PUBLISH_FINDING_TO_SNS;
+import static com.amazonaws.iot.mitigationaction.TestConstants.SDK_SYSTEM_TAG;
+import static com.amazonaws.iot.mitigationaction.TestConstants.SYSTEM_TAG_MAP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -90,9 +94,10 @@ public class UpdateHandlerTest {
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceState(desiredModel)
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(PREVIOUS_SDK_RESOURCE_TAG))
+        doReturn(ImmutableSet.of(PREVIOUS_SDK_RESOURCE_TAG, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, ACTION_ARN, logger);
 
@@ -145,9 +150,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(previousTag))
+        doReturn(ImmutableSet.of(previousTag, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, ACTION_ARN, logger);
 
@@ -168,9 +174,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(PREVIOUS_SDK_RESOURCE_TAG))
+        doReturn(ImmutableSet.of(PREVIOUS_SDK_RESOURCE_TAG, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, ACTION_ARN, logger);
 
@@ -212,6 +219,7 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(ImmutableMap.of("DesiredTagKey", "DesiredTagValue"))
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/CreateHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/CreateHandler.java
@@ -34,7 +34,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             CallbackContext callbackContext,
             Logger logger) {
 
-        CreateScheduledAuditRequest createRequest = translateToCreateRequest(request);
+        CreateScheduledAuditRequest createRequest = translateToCreateRequest(request, logger);
 
         ResourceModel model = request.getDesiredResourceState();
         if (!StringUtils.isEmpty(model.getScheduledAuditArn())) {
@@ -62,7 +62,9 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         return ProgressEvent.defaultSuccessHandler(model);
     }
 
-    private CreateScheduledAuditRequest translateToCreateRequest(ResourceHandlerRequest<ResourceModel> request) {
+    private CreateScheduledAuditRequest translateToCreateRequest(
+            ResourceHandlerRequest<ResourceModel> request,
+            Logger logger) {
 
         ResourceModel model = request.getDesiredResourceState();
 
@@ -85,6 +87,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             // There are also system tags provided separately.
             // SystemTags are the default stack-level tags with aws:cloudformation prefix
             allTags.putAll(request.getSystemTags());
+        } else {
+            // System tags should always be present as long as the Handler is called by CloudFormation
+            logger.log("Unexpectedly, system tags are null in the create request for " +
+                       ResourceModel.TYPE_NAME + " " + model.getScheduledAuditName());
         }
 
         // Note that the handlers act as pass-through in terms of input validation.

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/CreateHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/CreateHandler.java
@@ -13,6 +13,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class CreateHandler extends BaseHandler<CallbackContext> {
@@ -73,12 +74,18 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                     request.getClientRequestToken(), GENERATED_NAME_MAX_LENGTH));
         }
 
-        // getDesiredResourceTags combines the model and stack-level tags.
-        // Reference: https://tinyurl.com/yyxtd7w6
-        Map<String, String> tags = request.getDesiredResourceTags();
-        // TODO: uncomment this after we update the service to allow these (only from CFN)
-        // SystemTags are the default stack-level tags with aws:cloudformation prefix
-        // tags.putAll(request.getSystemTags());
+        // Combine all tags in one map that we'll use for the request
+        Map<String, String> allTags = new HashMap<>();
+        if (request.getDesiredResourceTags() != null) {
+            // DesiredResourceTags includes both model and stack-level tags.
+            // Reference: https://tinyurl.com/yyxtd7w6
+            allTags.putAll(request.getDesiredResourceTags());
+        }
+        if (request.getSystemTags() != null) {
+            // There are also system tags provided separately.
+            // SystemTags are the default stack-level tags with aws:cloudformation prefix
+            allTags.putAll(request.getSystemTags());
+        }
 
         // Note that the handlers act as pass-through in terms of input validation.
         // We have some validations in the json model, but we delegate deeper checks to the service.
@@ -89,7 +96,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 .dayOfMonth(model.getDayOfMonth())
                 .dayOfWeek(model.getDayOfWeek())
                 .targetCheckNames(model.getTargetCheckNames())
-                .tags(Translator.translateTagsToSdk(tags))
+                .tags(Translator.translateTagsToSdk(allTags))
                 .build();
     }
 }

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/UpdateHandler.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/UpdateHandler.java
@@ -14,8 +14,10 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -97,12 +99,24 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // Yet we should, otherwise the resource wouldn't equate the template.
         Set<Tag> currentTags = listTags(proxy, resourceArn, logger);
 
-        // getDesiredResourceTags includes model+stack-level tags, reference: https://tinyurl.com/y2p8medk
-        Set<Tag> desiredTags = Translator.translateTagsToSdk(request.getDesiredResourceTags());
-        // TODO: uncomment this after we update the service to allow these (only from CFN)
-        // SystemTags are the default stack-level tags with aws:cloudformation prefix
-        // desiredTags.addAll(Translator.translateTagsToSdk(request.getSystemTags()));
+        // Combine all tags in one map that we'll use for the request
+        Map<String, String> allDesiredTagsMap = new HashMap<>();
+        if (request.getDesiredResourceTags() != null) {
+            // DesiredResourceTags includes both model and stack-level tags.
+            // Reference: https://tinyurl.com/yyxtd7w6
+            allDesiredTagsMap.putAll(request.getDesiredResourceTags());
+        }
+        if (request.getSystemTags() != null) {
+            // There are also system tags provided separately.
+            // SystemTags are the default stack-level tags with aws:cloudformation prefix.
+            allDesiredTagsMap.putAll(request.getSystemTags());
+        } else {
+            // System tags should never get updated as they are the stack id, stack name,
+            // and logical resource id.
+            logger.log("Unexpectedly, system tags are null in the update request for " + resourceArn);
+        }
 
+        Set<Tag> desiredTags = Translator.translateTagsToSdk(allDesiredTagsMap);
         Set<String> desiredTagKeys = desiredTags.stream()
                 .map(Tag::key)
                 .collect(Collectors.toSet());

--- a/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/TestConstants.java
+++ b/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/TestConstants.java
@@ -33,7 +33,8 @@ public class TestConstants {
                     .value("resourceTagValue")
                     .build());
     protected static final Map<String, String> DESIRED_TAGS = ImmutableMap.of(
-            "resourceTagKey", "resourceTagValue",
+            "resourceTagKey", "resourceTagValue");
+    protected static final Map<String, String> SYSTEM_TAG_MAP = ImmutableMap.of(
             "aws:cloudformation:stack-name", "UnitTestStack");
     protected static final software.amazon.awssdk.services.iot.model.Tag SDK_MODEL_TAG =
             software.amazon.awssdk.services.iot.model.Tag.builder()

--- a/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/UpdateHandlerTest.java
+++ b/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/UpdateHandlerTest.java
@@ -1,6 +1,8 @@
 package com.amazonaws.iot.scheduledaudit;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -33,6 +35,8 @@ import static com.amazonaws.iot.scheduledaudit.TestConstants.DAY_OF_WEEK_2;
 import static com.amazonaws.iot.scheduledaudit.TestConstants.FREQUENCY;
 import static com.amazonaws.iot.scheduledaudit.TestConstants.SCHEDULED_AUDIT_ARN;
 import static com.amazonaws.iot.scheduledaudit.TestConstants.SCHEDULED_AUDIT_NAME;
+import static com.amazonaws.iot.scheduledaudit.TestConstants.SDK_SYSTEM_TAG;
+import static com.amazonaws.iot.scheduledaudit.TestConstants.SYSTEM_TAG_MAP;
 import static com.amazonaws.iot.scheduledaudit.TestConstants.TARGET_CHECK_NAMES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -87,9 +91,10 @@ public class UpdateHandlerTest {
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceState(desiredModel)
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(PREVIOUS_SDK_RESOURCE_TAG))
+        doReturn(ImmutableSet.of(PREVIOUS_SDK_RESOURCE_TAG, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, SCHEDULED_AUDIT_ARN, logger);
 
@@ -146,9 +151,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(previousTag))
+        doReturn(ImmutableSet.of(previousTag, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, SCHEDULED_AUDIT_ARN, logger);
 
@@ -170,9 +176,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(Collections.singleton(PREVIOUS_SDK_RESOURCE_TAG))
+        doReturn(ImmutableSet.of(PREVIOUS_SDK_RESOURCE_TAG, SDK_SYSTEM_TAG))
                 .when(handler)
                 .listTags(proxy, SCHEDULED_AUDIT_ARN, logger);
 
@@ -222,6 +229,7 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(ImmutableMap.of("DesiredTagKey", "DesiredTagValue"))
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/CreateHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/CreateHandler.java
@@ -15,6 +15,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -99,12 +100,18 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                     request.getClientRequestToken(), GENERATED_NAME_MAX_LENGTH));
         }
 
-        // getDesiredResourceTags combines the model and stack-level tags.
-        // Reference: https://tinyurl.com/yyxtd7w6
-        Map<String, String> tags = request.getDesiredResourceTags();
-        // TODO: uncomment this after we update the service to allow these (only from CFN)
-        // SystemTags are the default stack-level tags with aws:cloudformation prefix
-        // tags.putAll(request.getSystemTags());
+        // Combine all tags in one map that we'll use for the request
+        Map<String, String> allTags = new HashMap<>();
+        if (request.getDesiredResourceTags() != null) {
+            // DesiredResourceTags includes both model and stack-level tags.
+            // Reference: https://tinyurl.com/yyxtd7w6
+            allTags.putAll(request.getDesiredResourceTags());
+        }
+        if (request.getSystemTags() != null) {
+            // There are also system tags provided separately.
+            // SystemTags are the default stack-level tags with aws:cloudformation prefix
+            allTags.putAll(request.getSystemTags());
+        }
 
         // Note that the handlers act as pass-through in terms of input validation.
         // We have some validations in the json model, but we delegate deeper checks to the service.
@@ -116,7 +123,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 .alertTargetsWithStrings(Translator.translateAlertTargetMapFromCfnToIot(model.getAlertTargets()))
                 .additionalMetricsToRetainV2(Translator.translateMetricToRetainSetFromCfnToIot(
                         model.getAdditionalMetricsToRetainV2()))
-                .tags(Translator.translateTagsFromCfnToIot(tags))
+                .tags(Translator.translateTagsFromCfnToIot(allTags))
                 .build();
     }
 }

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/CreateHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/CreateHandler.java
@@ -38,7 +38,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             CallbackContext callbackContext,
             Logger logger) {
 
-        CreateSecurityProfileRequest createRequest = translateToCreateRequest(request);
+        CreateSecurityProfileRequest createRequest = translateToCreateRequest(request, logger);
 
         ResourceModel model = request.getDesiredResourceState();
         if (!StringUtils.isEmpty(model.getSecurityProfileArn())) {
@@ -88,7 +88,8 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
     }
 
     private CreateSecurityProfileRequest translateToCreateRequest(
-            ResourceHandlerRequest<ResourceModel> request) {
+            ResourceHandlerRequest<ResourceModel> request,
+            Logger logger) {
 
         ResourceModel model = request.getDesiredResourceState();
 
@@ -111,6 +112,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             // There are also system tags provided separately.
             // SystemTags are the default stack-level tags with aws:cloudformation prefix
             allTags.putAll(request.getSystemTags());
+        } else {
+            // System tags should always be present as long as the Handler is called by CloudFormation
+            logger.log("Unexpectedly, system tags are null in the create request for " +
+                       ResourceModel.TYPE_NAME + " " + model.getSecurityProfileName());
         }
 
         // Note that the handlers act as pass-through in terms of input validation.

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/UpdateHandler.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/UpdateHandler.java
@@ -2,6 +2,7 @@ package com.amazonaws.iot.securityprofile;
 
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -196,13 +197,24 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // Yet we should, otherwise the resource wouldn't equate the template.
         Set<Tag> currentTags = listTags(proxy, resourceArn);
 
-        // getDesiredResourceTags includes model+stack-level tags, reference: https://tinyurl.com/y55mqrnc
-        Set<Tag> nullableDesiredTags = Translator.translateTagsFromCfnToIot(request.getDesiredResourceTags());
-        Set<Tag> desiredTags = nullableDesiredTags == null ? Collections.emptySet() : nullableDesiredTags;
-        // TODO: uncomment this after we update the service to allow these (only from CFN)
-        // SystemTags are the default stack-level tags with aws:cloudformation prefix
-        // desiredTags.addAll(Translator.translateTagsFromCfnToIot(request.getSystemTags()));
+        // Combine all tags in one map that we'll use for the request
+        Map<String, String> allDesiredTagsMap = new HashMap<>();
+        if (request.getDesiredResourceTags() != null) {
+            // DesiredResourceTags includes both model and stack-level tags.
+            // Reference: https://tinyurl.com/yyxtd7w6
+            allDesiredTagsMap.putAll(request.getDesiredResourceTags());
+        }
+        if (request.getSystemTags() != null) {
+            // There are also system tags provided separately.
+            // SystemTags are the default stack-level tags with aws:cloudformation prefix.
+            allDesiredTagsMap.putAll(request.getSystemTags());
+        } else {
+            // System tags should never get updated as they are the stack id, stack name,
+            // and logical resource id.
+            logger.log("Unexpectedly, system tags are null in the update request for " + resourceArn);
+        }
 
+        Set<Tag> desiredTags = Translator.translateTagsFromCfnToIot(allDesiredTagsMap);
         Set<String> desiredTagKeys = desiredTags.stream()
                 .map(Tag::key)
                 .collect(Collectors.toSet());

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/CreateHandlerTest.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/CreateHandlerTest.java
@@ -28,10 +28,13 @@ import static com.amazonaws.iot.securityprofile.TestConstants.CLIENT_REQUEST_TOK
 import static com.amazonaws.iot.securityprofile.TestConstants.LOGICAL_IDENTIFIER;
 import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_ARN;
 import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_NAME;
+import static com.amazonaws.iot.securityprofile.TestConstants.SYSTEM_TAG_IOT;
+import static com.amazonaws.iot.securityprofile.TestConstants.SYSTEM_TAG_MAP;
 import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_CFN_SET;
 import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_IOT;
 import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_STRINGMAP;
 import static com.amazonaws.iot.securityprofile.TestConstants.TARGET_ARNS;
+import static junit.framework.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -65,6 +68,7 @@ public class CreateHandlerTest {
                 .logicalResourceIdentifier(LOGICAL_IDENTIFIER)
                 .clientRequestToken(CLIENT_REQUEST_TOKEN)
                 .desiredResourceTags(TAG_1_STRINGMAP)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         CreateSecurityProfileResponse createResponse = CreateSecurityProfileResponse.builder()
@@ -84,12 +88,10 @@ public class CreateHandlerTest {
 
         List<IotRequest> iotRequests = requestsCaptor.getAllValues();
         CreateSecurityProfileRequest actualCreateRequest = (CreateSecurityProfileRequest) iotRequests.get(0);
-        CreateSecurityProfileRequest expectedCreateRequest = CreateSecurityProfileRequest.builder()
-                .securityProfileName(SECURITY_PROFILE_NAME)
-                .additionalMetricsToRetainV2(ADDITIONAL_METRICS_IOT)
-                .tags(TAG_1_IOT)
-                .build();
-        assertThat(actualCreateRequest).isEqualTo(expectedCreateRequest);
+        // Order doesn't matter for tags, but they're modeled as a List, thus we have to check field by field.
+        assertThat(actualCreateRequest.tags()).containsExactlyInAnyOrder(TAG_1_IOT, SYSTEM_TAG_IOT);
+        assertEquals(SECURITY_PROFILE_NAME, actualCreateRequest.securityProfileName());
+        assertEquals(ADDITIONAL_METRICS_IOT, actualCreateRequest.additionalMetricsToRetainV2());
 
         AttachSecurityProfileRequest actualAttachRequest1 = (AttachSecurityProfileRequest) iotRequests.get(1);
         assertThat(actualAttachRequest1.securityProfileName()).isEqualTo(SECURITY_PROFILE_NAME);
@@ -237,6 +239,4 @@ public class CreateHandlerTest {
                 .tags(TAG_1_CFN_SET)
                 .build();
     }
-
-    // TODO: test system tags when the src code is ready
 }

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/ReadHandlerTest.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/ReadHandlerTest.java
@@ -9,8 +9,9 @@ import static com.amazonaws.iot.securityprofile.TestConstants.BEHAVIOR_1_IOT;
 import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_ARN;
 import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_DESCRIPTION;
 import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_NAME;
-import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_CFN_SET;
-import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_IOT_SET;
+import static com.amazonaws.iot.securityprofile.TestConstants.SYSTEM_TAG_IOT;
+import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_AND_SYSTEM_TAG_CFN_SET;
+import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_IOT;
 import static com.amazonaws.iot.securityprofile.TestConstants.TARGET_ARN_1_SET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -21,6 +22,8 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,7 +84,7 @@ public class ReadHandlerTest {
                 .when(handler)
                 .listTargetsForSecurityProfile(proxy, SECURITY_PROFILE_NAME);
 
-        doReturn(TAG_1_IOT_SET)
+        doReturn(ImmutableSet.of(TAG_1_IOT, SYSTEM_TAG_IOT))
                 .when(handler)
                 .listTags(proxy, SECURITY_PROFILE_ARN);
 
@@ -104,7 +107,7 @@ public class ReadHandlerTest {
                 .alertTargets(ALERT_TARGET_MAP_CFN)
                 .additionalMetricsToRetainV2(ADDITIONAL_METRICS_CFN)
                 .targetArns(TARGET_ARN_1_SET)
-                .tags(TAG_1_CFN_SET)
+                .tags(TAG_1_AND_SYSTEM_TAG_CFN_SET)
                 .build();
         assertThat(response.getResourceModel()).isEqualTo(expectedModel);
     }
@@ -127,7 +130,7 @@ public class ReadHandlerTest {
                 .additionalMetricsToRetainV2(additionalMetricsV2)
                 .build();
 
-        ResourceModel actualModel = handler.buildResourceModel(describeResponse, TARGET_ARN_1_SET, TAG_1_IOT_SET);
+        ResourceModel actualModel = handler.buildResourceModel(describeResponse, TARGET_ARN_1_SET, null);
 
         ResourceModel expectedModel = ResourceModel.builder()
                 .securityProfileName(SECURITY_PROFILE_NAME)
@@ -137,7 +140,6 @@ public class ReadHandlerTest {
                 .alertTargets(null)
                 .additionalMetricsToRetainV2(null)
                 .targetArns(TARGET_ARN_1_SET)
-                .tags(TAG_1_CFN_SET)
                 .build();
         assertThat(actualModel).isEqualTo(expectedModel);
     }

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TestConstants.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TestConstants.java
@@ -52,10 +52,21 @@ public class TestConstants {
                     .key(TAG_1_KEY)
                     .value("TagValue1")
                     .build());
+    static final Set<Tag> TAG_1_AND_SYSTEM_TAG_CFN_SET = ImmutableSet.of(
+            Tag.builder()
+                    .key(TAG_1_KEY)
+                    .value("TagValue1")
+                    .build(),
+            Tag.builder()
+                    .key("aws:cloudformation:stack-name")
+                    .value("UnitTestStack")
+                    .build());
     static final Map<String, String> TAG_1_STRINGMAP = ImmutableMap.of(
             TAG_1_KEY, "TagValue1");
     static final Map<String, String> TAG_2_STRINGMAP = ImmutableMap.of(
             "TagKey2", "TagValue2");
+    static final Map<String, String> SYSTEM_TAG_MAP = ImmutableMap.of(
+            "aws:cloudformation:stack-name", "UnitTestStack");
     static final software.amazon.awssdk.services.iot.model.Tag TAG_1_IOT =
             software.amazon.awssdk.services.iot.model.Tag.builder()
                     .key(TAG_1_KEY)
@@ -66,8 +77,15 @@ public class TestConstants {
                     .key("TagKey2")
                     .value("TagValue2")
                     .build();
-    static final Set<software.amazon.awssdk.services.iot.model.Tag> TAG_1_IOT_SET = ImmutableSet.of(TAG_1_IOT);
-    static final List<software.amazon.awssdk.services.iot.model.Tag> TAG_2_IOT_LIST = ImmutableList.of(TAG_2_IOT);
+    static final software.amazon.awssdk.services.iot.model.Tag SYSTEM_TAG_IOT =
+            software.amazon.awssdk.services.iot.model.Tag.builder()
+                    .key("aws:cloudformation:stack-name")
+                    .value("UnitTestStack")
+                    .build();
+    static final Set<software.amazon.awssdk.services.iot.model.Tag> TAG_1_IOT_SET =
+            ImmutableSet.of(TAG_1_IOT);
+    static final List<software.amazon.awssdk.services.iot.model.Tag> TAG_2_IOT_LIST =
+            ImmutableList.of(TAG_2_IOT);
     static final Set<software.amazon.awssdk.services.iot.model.Tag> TAGS_IOT =
             ImmutableSet.of(TAG_1_IOT, TAG_2_IOT);
     static final software.amazon.awssdk.services.iot.model.SecurityProfileTarget SECURITY_PROFILE_TARGET_1 =

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/UpdateHandlerTest.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/UpdateHandlerTest.java
@@ -9,7 +9,9 @@ import static com.amazonaws.iot.securityprofile.TestConstants.BEHAVIOR_1_IOT_LIS
 import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_ARN;
 import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_DESCRIPTION;
 import static com.amazonaws.iot.securityprofile.TestConstants.SECURITY_PROFILE_NAME;
-import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_IOT_SET;
+import static com.amazonaws.iot.securityprofile.TestConstants.SYSTEM_TAG_IOT;
+import static com.amazonaws.iot.securityprofile.TestConstants.SYSTEM_TAG_MAP;
+import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_IOT;
 import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_KEY;
 import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_KEY_LIST;
 import static com.amazonaws.iot.securityprofile.TestConstants.TAG_1_STRINGMAP;
@@ -97,12 +99,13 @@ public class UpdateHandlerTest {
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceState(desiredModel)
                 .desiredResourceTags(TAG_2_STRINGMAP)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         doReturn(TARGET_ARN_1_SET)
                 .when(handler)
                 .listTargetsForSecurityProfile(proxy, SECURITY_PROFILE_NAME);
-        doReturn(TAG_1_IOT_SET)
+        doReturn(ImmutableSet.of(TAG_1_IOT, SYSTEM_TAG_IOT))
                 .when(handler)
                 .listTags(proxy, SECURITY_PROFILE_ARN);
 
@@ -259,9 +262,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTagsCfn)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(TAG_1_IOT_SET)
+        doReturn(ImmutableSet.of(TAG_1_IOT, SYSTEM_TAG_IOT))
                 .when(handler)
                 .listTags(proxy, SECURITY_PROFILE_ARN);
 
@@ -282,9 +286,10 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(ImmutableMap.of("doesn't", "matter"))
                 .desiredResourceTags(desiredTags)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        doReturn(TAG_1_IOT_SET)
+        doReturn(ImmutableSet.of(TAG_1_IOT, SYSTEM_TAG_IOT))
                 .when(handler)
                 .listTags(proxy, SECURITY_PROFILE_ARN);
 
@@ -330,6 +335,7 @@ public class UpdateHandlerTest {
                 .previousResourceState(ResourceModel.builder().build())
                 .previousResourceTags(TAG_1_STRINGMAP)
                 .desiredResourceTags(TAG_1_STRINGMAP)
+                .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
         when(proxy.injectCredentialsAndInvokeV2(any(), any()))


### PR DESCRIPTION
### Notes
The IoT's Create APIs for these 5 resources now accept system tags when the resource gets created through CloudFormation. Now the resource provider handlers here can include system tags in the requests, which is what this change does.

### Testing
* Registered these handlers privately and verified the behavior with integration tests
* Unit tests
* Ran `mvn verify`, `pre-commit run --all-files`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
