### PR TITLE
Add MLAD related fields to the AWS::IoT::SecurityProfile resource.

### DIFF
--- a/aws-iot-securityprofile/aws-iot-securityprofile.json
+++ b/aws-iot-securityprofile/aws-iot-securityprofile.json
@@ -26,6 +26,10 @@
         },
         "Criteria": {
           "$ref": "#/definitions/BehaviorCriteria"
+        },
+        "SuppressAlerts": {
+          "description": "Manage Detect alarm SNS notifications by setting behavior notification to on or suppressed. Detect will continue to performing device behavior evaluations. However, suppressed alarms wouldn't be forwarded for SNS notification.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -99,6 +103,9 @@
         },
         "StatisticalThreshold": {
           "$ref": "#/definitions/StatisticalThreshold"
+        },
+        "MlDetectionConfig": {
+          "$ref": "#/definitions/MachineLearningDetectionConfig"
         }
       },
       "additionalProperties": false
@@ -177,6 +184,22 @@
             "p99.9",
             "p99.99",
             "p100"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "MachineLearningDetectionConfig": {
+      "description": "The configuration of an ML Detect Security Profile.",
+      "type": "object",
+      "properties": {
+        "ConfidenceLevel": {
+          "description": "The sensitivity of anomalous behavior evaluation. Can be Low, Medium, or High.",
+          "type": "string",
+          "enum": [
+            "LOW",
+            "MEDIUM",
+            "HIGH"
           ]
         }
       },

--- a/aws-iot-securityprofile/pom.xml
+++ b/aws-iot-securityprofile/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>iot</artifactId>
-            <version>2.15.47</version>
+            <version>2.15.77</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/Translator.java
+++ b/aws-iot-securityprofile/src/main/java/com/amazonaws/iot/securityprofile/Translator.java
@@ -51,6 +51,7 @@ public class Translator {
                 .metric(cfnBehavior.getMetric())
                 .metricDimension(translateMetricDimensionFromCfnToIot(cfnBehavior.getMetricDimension()))
                 .criteria(translateBehaviorCriteriaFromCfnToIot(cfnBehavior.getCriteria()))
+                .suppressAlerts(cfnBehavior.getSuppressAlerts())
                 .build();
     }
 
@@ -61,6 +62,7 @@ public class Translator {
                 .metric(iotBehavior.metric())
                 .metricDimension(translateMetricDimensionFromIotToCfn(iotBehavior.metricDimension()))
                 .criteria(translateBehaviorCriteriaFromIotToCfn(iotBehavior.criteria()))
+                .suppressAlerts(iotBehavior.suppressAlerts())
                 .build();
     }
 
@@ -76,6 +78,7 @@ public class Translator {
                 .consecutiveDatapointsToAlarm(cfnCriteria.getConsecutiveDatapointsToAlarm())
                 .consecutiveDatapointsToClear(cfnCriteria.getConsecutiveDatapointsToClear())
                 .statisticalThreshold(translateStatisticalThresholdFromCfnToIot(cfnCriteria.getStatisticalThreshold()))
+                .mlDetectionConfig(translateMlDetectionConfigFromCfnToIot(cfnCriteria.getMlDetectionConfig()))
                 .build();
     }
 
@@ -91,6 +94,7 @@ public class Translator {
                 .consecutiveDatapointsToAlarm(iotCriteria.consecutiveDatapointsToAlarm())
                 .consecutiveDatapointsToClear(iotCriteria.consecutiveDatapointsToClear())
                 .statisticalThreshold(translateStatisticalThresholdFromIotToCfn(iotCriteria.statisticalThreshold()))
+                .mlDetectionConfig(translateMlDetectionConfigFromIotToCfn(iotCriteria.mlDetectionConfig()))
                 .build();
     }
 
@@ -190,6 +194,16 @@ public class Translator {
                 .build();
     }
 
+    private static software.amazon.awssdk.services.iot.model.MachineLearningDetectionConfig translateMlDetectionConfigFromCfnToIot(
+            MachineLearningDetectionConfig machineLearningDetectionConfig) {
+        if (machineLearningDetectionConfig == null) {
+            return null;
+        }
+        return software.amazon.awssdk.services.iot.model.MachineLearningDetectionConfig.builder()
+                .confidenceLevel(machineLearningDetectionConfig.getConfidenceLevel())
+                .build();
+    }
+
     private static StatisticalThreshold translateStatisticalThresholdFromIotToCfn(
             software.amazon.awssdk.services.iot.model.StatisticalThreshold iotThreshold) {
         if (iotThreshold == null) {
@@ -199,6 +213,17 @@ public class Translator {
                 .statistic(iotThreshold.statistic())
                 .build();
     }
+
+    private static MachineLearningDetectionConfig translateMlDetectionConfigFromIotToCfn(
+            software.amazon.awssdk.services.iot.model.MachineLearningDetectionConfig mlDetectionConfig) {
+        if (mlDetectionConfig == null) {
+            return null;
+        }
+        return MachineLearningDetectionConfig.builder()
+                .confidenceLevel(mlDetectionConfig.confidenceLevelAsString())
+                .build();
+    }
+
 
     static Map<String, software.amazon.awssdk.services.iot.model.AlertTarget> translateAlertTargetMapFromCfnToIot(
             Map<String, AlertTarget> cfnAlertTargetMap) {

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TranslatorTest.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TranslatorTest.java
@@ -125,11 +125,14 @@ public class TranslatorTest {
                 .comparisonOperator("greater-than")
                 .durationSeconds(300)
                 .statisticalThreshold(StatisticalThreshold.builder().statistic("p90").build())
+                .mlDetectionConfig(MachineLearningDetectionConfig
+                        .builder().confidenceLevel("HIGH").build())
                 .build();
         return Behavior.builder()
                 .name(BEHAVIOR_NAME)
                 .metric("aws:num-authorization-failures")
                 .criteria(behaviorCriteria)
+                .suppressAlerts(true)
                 .build();
     }
 
@@ -140,11 +143,14 @@ public class TranslatorTest {
                         .durationSeconds(300)
                         .statisticalThreshold(software.amazon.awssdk.services.iot.model.StatisticalThreshold
                                 .builder().statistic("p90").build())
+                        .mlDetectionConfig(software.amazon.awssdk.services.iot.model.MachineLearningDetectionConfig
+                                .builder().confidenceLevel("HIGH").build())
                         .build();
         return software.amazon.awssdk.services.iot.model.Behavior.builder()
                 .name(BEHAVIOR_NAME)
                 .metric("aws:num-authorization-failures")
                 .criteria(behaviorCriteria)
+                .suppressAlerts(true)
                 .build();
     }
 
@@ -154,11 +160,14 @@ public class TranslatorTest {
                 .durationSeconds(600)
                 .value(MetricValue
                         .builder().count("999999999999").build())
+                .mlDetectionConfig(MachineLearningDetectionConfig
+                        .builder().confidenceLevel("MEDIUM").build())
                 .build();
         return Behavior.builder()
                 .name(BEHAVIOR_NAME)
                 .metric("aws:num-messages-sent")
                 .criteria(behaviorCriteria)
+                .suppressAlerts(false)
                 .build();
     }
 
@@ -169,11 +178,14 @@ public class TranslatorTest {
                         .durationSeconds(600)
                         .value(software.amazon.awssdk.services.iot.model.MetricValue
                                 .builder().count(999999999999L).build())
+                        .mlDetectionConfig(software.amazon.awssdk.services.iot.model.MachineLearningDetectionConfig
+                                .builder().confidenceLevel("MEDIUM").build())
                         .build();
         return software.amazon.awssdk.services.iot.model.Behavior.builder()
                 .name(BEHAVIOR_NAME)
                 .metric("aws:num-messages-sent")
                 .criteria(behaviorCriteria)
+                .suppressAlerts(false)
                 .build();
     }
 


### PR DESCRIPTION
*Description of changes:*
Adding the MLAD public preview related fields to AWS::IoT::SecurityProfile.
1) SuppressAlerts:  This is part of Behavior structure. Allows managing Detect alarm SNS notifications by setting behavior notification to on or suppressed. Detect will continue to performing device behavior evaluations. However, suppressed alarms wouldn't be forwarded for SNS notification.
More details at: https://docs.aws.amazon.com/iot/latest/developerguide/detect-behaviors.html
2) MlDetectionConfig: This is part of Behavior Criteria structure. Right now the structure on contains the property ConfidenceLevel. More details at: https://docs.aws.amazon.com/iot/latest/developerguide/detect-behaviors.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
