### PR TITLE
Change model for AWS::IoT::AccountAuditConfiguration to now have bett…

### DIFF
--- a/aws-iot-accountauditconfiguration/aws-iot-accountauditconfiguration.json
+++ b/aws-iot-accountauditconfiguration/aws-iot-accountauditconfiguration.json
@@ -46,8 +46,47 @@
     "AuditCheckConfigurations": {
       "description": "Specifies which audit checks are enabled and disabled for this account.",
       "type": "object",
-      "patternProperties": {
-        "[A-Z_]+": {
+      "properties": {
+        "AuthenticatedCognitoRoleOverlyPermissiveCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "CaCertificateExpiringCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "CaCertificateKeyQualityCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "ConflictingClientIdsCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "DeviceCertificateExpiringCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "DeviceCertificateKeyQualityCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "DeviceCertificateSharedCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "IotPolicyOverlyPermissiveCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "IotRoleAliasAllowsAccessToUnusedServicesCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "IotRoleAliasOverlyPermissiveCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "LoggingDisabledCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "RevokedCaCertificateStillActiveCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "RevokedDeviceCertificateStillActiveCheck": {
+          "$ref": "#/definitions/AuditCheckConfiguration"
+        },
+        "UnauthenticatedCognitoRoleOverlyPermissiveCheck": {
           "$ref": "#/definitions/AuditCheckConfiguration"
         }
       },
@@ -56,8 +95,8 @@
     "AuditNotificationTargetConfigurations": {
       "description": "Information about the targets to which audit notifications are sent.",
       "type": "object",
-      "patternProperties": {
-        "[a-zA-Z0-9:_-]+": {
+      "properties": {
+        "Sns": {
           "$ref": "#/definitions/AuditNotificationTarget"
         }
       },

--- a/aws-iot-accountauditconfiguration/aws-iot-accountauditconfiguration.json
+++ b/aws-iot-accountauditconfiguration/aws-iot-accountauditconfiguration.json
@@ -3,46 +3,6 @@
   "description": "Configures the Device Defender audit settings for this account. Settings include how audit notifications are sent and which audit checks are enabled or disabled.",
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-iot.git",
   "definitions": {
-    "AuditCheckConfiguration": {
-      "description": "The configuration for a specific audit check.",
-      "type": "object",
-      "properties": {
-        "Enabled": {
-          "description": "True if the check is enabled.",
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
-    "AuditNotificationTarget": {
-      "type": "object",
-      "properties": {
-        "TargetArn": {
-          "description": "The ARN of the target (SNS topic) to which audit notifications are sent.",
-          "type": "string",
-          "maxLength": 2048
-        },
-        "RoleArn": {
-          "description": "The ARN of the role that grants permission to send notifications to the target.",
-          "type": "string",
-          "minLength": 20,
-          "maxLength": 2048
-        },
-        "Enabled": {
-          "description": "True if notifications to the target are enabled.",
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    }
-  },
-  "properties": {
-    "AccountId": {
-      "description": "Your 12-digit account ID (used as the primary identifier for the CloudFormation resource).",
-      "type": "string",
-      "minLength": 12,
-      "maxLength": 12
-    },
     "AuditCheckConfigurations": {
       "description": "Specifies which audit checks are enabled and disabled for this account.",
       "type": "object",
@@ -101,6 +61,52 @@
         }
       },
       "additionalProperties": false
+    },
+    "AuditCheckConfiguration": {
+      "description": "The configuration for a specific audit check.",
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "description": "True if the check is enabled.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuditNotificationTarget": {
+      "type": "object",
+      "properties": {
+        "TargetArn": {
+          "description": "The ARN of the target (SNS topic) to which audit notifications are sent.",
+          "type": "string",
+          "maxLength": 2048
+        },
+        "RoleArn": {
+          "description": "The ARN of the role that grants permission to send notifications to the target.",
+          "type": "string",
+          "minLength": 20,
+          "maxLength": 2048
+        },
+        "Enabled": {
+          "description": "True if notifications to the target are enabled.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "AccountId": {
+      "description": "Your 12-digit account ID (used as the primary identifier for the CloudFormation resource).",
+      "type": "string",
+      "minLength": 12,
+      "maxLength": 12
+    },
+    "AuditCheckConfigurations": {
+      "$ref": "#/definitions/AuditCheckConfigurations"
+    },
+    "AuditNotificationTargetConfigurations": {
+      "$ref": "#/definitions/AuditNotificationTargetConfigurations"
     },
     "RoleArn": {
       "description": "The ARN of the role that grants permission to AWS IoT to access information about your devices, policies, certificates and other items as required when performing an audit.",

--- a/aws-iot-accountauditconfiguration/inputs/inputs_1_create.json
+++ b/aws-iot-accountauditconfiguration/inputs/inputs_1_create.json
@@ -1,11 +1,47 @@
 {
   "AccountId": "{{AccountId}}",
   "AuditCheckConfigurations": {
-    "LOGGING_DISABLED_CHECK": {
+    "AuthenticatedCognitoRoleOverlyPermissiveCheck": {
+      "Enabled": false
+    },
+    "CaCertificateExpiringCheck": {
+      "Enabled": false
+    },
+    "CaCertificateKeyQualityCheck": {
+      "Enabled": false
+    },
+    "ConflictingClientIdsCheck": {
       "Enabled": true
     },
-    "CA_CERTIFICATE_EXPIRING_CHECK": {
+    "DeviceCertificateExpiringCheck": {
+      "Enabled": false
+    },
+    "DeviceCertificateKeyQualityCheck": {
+      "Enabled": false
+    },
+    "DeviceCertificateSharedCheck": {
+      "Enabled": false
+    },
+    "IotPolicyOverlyPermissiveCheck": {
+      "Enabled": false
+    },
+    "IotRoleAliasAllowsAccessToUnusedServicesCheck": {
+      "Enabled": false
+    },
+    "IotRoleAliasOverlyPermissiveCheck": {
+      "Enabled": false
+    },
+    "LoggingDisabledCheck": {
       "Enabled": true
+    },
+    "RevokedCaCertificateStillActiveCheck": {
+      "Enabled": false
+    },
+    "RevokedDeviceCertificateStillActiveCheck": {
+      "Enabled": false
+    },
+    "UnauthenticatedCognitoRoleOverlyPermissiveCheck": {
+      "Enabled": false
     }
   },
   "RoleArn": "{{RoleForDeviceDefenderAuditArn}}"

--- a/aws-iot-accountauditconfiguration/inputs/inputs_1_invalid.json
+++ b/aws-iot-accountauditconfiguration/inputs/inputs_1_invalid.json
@@ -1,10 +1,10 @@
 {
   "AccountId": "{{AccountId}}",
   "AuditCheckConfigurations": {
-    "NON_EXISTENT_CHECK": {
+    "NonExistentCheck": {
       "Enabled": true
     },
-    "CA_CERTIFICATE_EXPIRING_CHECK": {
+    "CaCertificateExpiringCheck": {
       "Enabled": true
     }
   },

--- a/aws-iot-accountauditconfiguration/inputs/inputs_1_update.json
+++ b/aws-iot-accountauditconfiguration/inputs/inputs_1_update.json
@@ -1,14 +1,47 @@
 {
   "AccountId": "{{AccountId}}",
   "AuditCheckConfigurations": {
-    "LOGGING_DISABLED_CHECK": {
+    "AuthenticatedCognitoRoleOverlyPermissiveCheck": {
+      "Enabled": false
+    },
+    "CaCertificateExpiringCheck": {
+      "Enabled": false
+    },
+    "CaCertificateKeyQualityCheck": {
+      "Enabled": false
+    },
+    "ConflictingClientIdsCheck": {
       "Enabled": true
     },
-    "CA_CERTIFICATE_EXPIRING_CHECK": {
+    "DeviceCertificateExpiringCheck": {
       "Enabled": true
     },
-    "DEVICE_CERTIFICATE_EXPIRING_CHECK": {
+    "DeviceCertificateKeyQualityCheck": {
+      "Enabled": false
+    },
+    "DeviceCertificateSharedCheck": {
+      "Enabled": false
+    },
+    "IotPolicyOverlyPermissiveCheck": {
+      "Enabled": false
+    },
+    "IotRoleAliasAllowsAccessToUnusedServicesCheck": {
+      "Enabled": false
+    },
+    "IotRoleAliasOverlyPermissiveCheck": {
+      "Enabled": false
+    },
+    "LoggingDisabledCheck": {
       "Enabled": true
+    },
+    "RevokedCaCertificateStillActiveCheck": {
+      "Enabled": false
+    },
+    "RevokedDeviceCertificateStillActiveCheck": {
+      "Enabled": false
+    },
+    "UnauthenticatedCognitoRoleOverlyPermissiveCheck": {
+      "Enabled": false
     }
   },
   "RoleArn": "{{RoleForDeviceDefenderAuditArn}}"

--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/ReadHandler.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/ReadHandler.java
@@ -54,10 +54,10 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                     "The configuration for your account has not been set up or was deleted.");
         }
 
-        Map<String, AuditCheckConfiguration> auditCheckConfigurationsCfn = Translator.translateChecksFromIotToCfn(
+        AuditCheckConfigurations auditCheckConfigurationsCfn = Translator.translateChecksFromIotToCfn(
                 describeResponse.auditCheckConfigurations());
 
-        Map<String, AuditNotificationTarget> notificationTargetsCfn = Translator.translateNotificationsFromIotToCfn(
+        AuditNotificationTargetConfigurations notificationTargetsCfn = Translator.translateNotificationsFromIotToCfn(
                 describeResponse.auditNotificationTargetConfigurationsAsStrings());
 
         ResourceModel model = ResourceModel.builder()

--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/Translator.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/Translator.java
@@ -1,21 +1,15 @@
 package com.amazonaws.iot.accountauditconfiguration;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.services.iot.model.InternalFailureException;
 import software.amazon.awssdk.services.iot.model.InvalidRequestException;
-import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.ThrottlingException;
 import software.amazon.awssdk.services.iot.model.UnauthorizedException;
-import software.amazon.cloudformation.exceptions.BaseHandlerException;
-import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
-import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnThrottlingException;
+import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -67,12 +61,70 @@ public class Translator {
 
     static Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> translateChecksFromCfnToIot(ResourceModel model) {
 
-        return model.getAuditCheckConfigurations()
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> translateCheckConfigurationFromCfnToIot(e.getValue())));
+        // TODO: test empty template
+
+        Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> iotMap = new HashMap<>();
+
+        AuditCheckConfigurations auditCheckConfigurations = model.getAuditCheckConfigurations();
+
+        if (auditCheckConfigurations.getAuthenticatedCognitoRoleOverlyPermissiveCheck() != null) {
+            iotMap.put("AUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getAuthenticatedCognitoRoleOverlyPermissiveCheck()));
+        }
+        if (auditCheckConfigurations.getCaCertificateExpiringCheck() != null) {
+            iotMap.put("CA_CERTIFICATE_EXPIRING_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getCaCertificateExpiringCheck()));
+        }
+        if (auditCheckConfigurations.getCaCertificateKeyQualityCheck() != null) {
+            iotMap.put("CA_CERTIFICATE_KEY_QUALITY_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getCaCertificateKeyQualityCheck()));
+        }
+        if (auditCheckConfigurations.getConflictingClientIdsCheck() != null) {
+            iotMap.put("CONFLICTING_CLIENT_IDS_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getConflictingClientIdsCheck()));
+        }
+        if (auditCheckConfigurations.getDeviceCertificateExpiringCheck() != null) {
+            iotMap.put("DEVICE_CERTIFICATE_EXPIRING_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getDeviceCertificateExpiringCheck()));
+        }
+        if (auditCheckConfigurations.getDeviceCertificateKeyQualityCheck() != null) {
+            iotMap.put("DEVICE_CERTIFICATE_KEY_QUALITY_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getDeviceCertificateKeyQualityCheck()));
+        }
+        if (auditCheckConfigurations.getDeviceCertificateSharedCheck() != null) {
+            iotMap.put("DEVICE_CERTIFICATE_SHARED_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getDeviceCertificateSharedCheck()));
+        }
+        if (auditCheckConfigurations.getIotPolicyOverlyPermissiveCheck() != null) {
+            iotMap.put("IOT_POLICY_OVERLY_PERMISSIVE_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getIotPolicyOverlyPermissiveCheck()));
+        }
+        if (auditCheckConfigurations.getIotRoleAliasAllowsAccessToUnusedServicesCheck() != null) {
+            iotMap.put("IOT_ROLE_ALIAS_ALLOWS_ACCESS_TO_UNUSED_SERVICES_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getIotRoleAliasAllowsAccessToUnusedServicesCheck()));
+        }
+        if (auditCheckConfigurations.getIotRoleAliasOverlyPermissiveCheck() != null) {
+            iotMap.put("IOT_ROLE_ALIAS_OVERLY_PERMISSIVE_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getIotRoleAliasOverlyPermissiveCheck()));
+        }
+        if (auditCheckConfigurations.getLoggingDisabledCheck() != null) {
+            iotMap.put("LOGGING_DISABLED_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getLoggingDisabledCheck()));
+        }
+        if (auditCheckConfigurations.getRevokedCaCertificateStillActiveCheck() != null) {
+            iotMap.put("REVOKED_CA_CERTIFICATE_STILL_ACTIVE_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getRevokedCaCertificateStillActiveCheck()));
+        }
+        if (auditCheckConfigurations.getRevokedDeviceCertificateStillActiveCheck() != null) {
+            iotMap.put("REVOKED_DEVICE_CERTIFICATE_STILL_ACTIVE_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getRevokedDeviceCertificateStillActiveCheck()));
+        }
+        if (auditCheckConfigurations.getUnauthenticatedCognitoRoleOverlyPermissiveCheck() != null) {
+            iotMap.put("UNAUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK", translateCheckConfigurationFromCfnToIot(
+                    auditCheckConfigurations.getUnauthenticatedCognitoRoleOverlyPermissiveCheck()));
+        }
+
+        return iotMap;
     }
 
     static software.amazon.awssdk.services.iot.model.AuditCheckConfiguration translateCheckConfigurationFromCfnToIot(
@@ -83,38 +135,99 @@ public class Translator {
                 .build();
     }
 
-    static Map<String, AuditCheckConfiguration> translateChecksFromIotToCfn(
+    static AuditCheckConfigurations translateChecksFromIotToCfn(
             Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> iotMap) {
 
-        return iotMap.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> AuditCheckConfiguration.builder().enabled(e.getValue().enabled()).build()));
-    }
+        AuditCheckConfigurations translation = new AuditCheckConfigurations();
 
-    static Set<String> getEnabledChecksSetFromIotMap(
-            Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> checkConfigurationMap) {
+        if (iotMap.containsKey("AUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK")) {
+            translation.setAuthenticatedCognitoRoleOverlyPermissiveCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("AUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("CA_CERTIFICATE_EXPIRING_CHECK")) {
+            translation.setCaCertificateExpiringCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("CA_CERTIFICATE_EXPIRING_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("CA_CERTIFICATE_KEY_QUALITY_CHECK")) {
+            translation.setCaCertificateKeyQualityCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("CA_CERTIFICATE_KEY_QUALITY_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("CONFLICTING_CLIENT_IDS_CHECK")) {
+            translation.setConflictingClientIdsCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("CONFLICTING_CLIENT_IDS_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("DEVICE_CERTIFICATE_EXPIRING_CHECK")) {
+            translation.setDeviceCertificateExpiringCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("DEVICE_CERTIFICATE_EXPIRING_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("DEVICE_CERTIFICATE_KEY_QUALITY_CHECK")) {
+            translation.setDeviceCertificateKeyQualityCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("DEVICE_CERTIFICATE_KEY_QUALITY_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("DEVICE_CERTIFICATE_SHARED_CHECK")) {
+            translation.setDeviceCertificateSharedCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("DEVICE_CERTIFICATE_SHARED_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("IOT_POLICY_OVERLY_PERMISSIVE_CHECK")) {
+            translation.setIotPolicyOverlyPermissiveCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("IOT_POLICY_OVERLY_PERMISSIVE_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("IOT_ROLE_ALIAS_ALLOWS_ACCESS_TO_UNUSED_SERVICES_CHECK")) {
+            translation.setIotRoleAliasAllowsAccessToUnusedServicesCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("IOT_ROLE_ALIAS_ALLOWS_ACCESS_TO_UNUSED_SERVICES_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("IOT_ROLE_ALIAS_OVERLY_PERMISSIVE_CHECK")) {
+            translation.setIotRoleAliasOverlyPermissiveCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("IOT_ROLE_ALIAS_OVERLY_PERMISSIVE_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("LOGGING_DISABLED_CHECK")) {
+            translation.setLoggingDisabledCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("LOGGING_DISABLED_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("REVOKED_CA_CERTIFICATE_STILL_ACTIVE_CHECK")) {
+            translation.setRevokedCaCertificateStillActiveCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("REVOKED_CA_CERTIFICATE_STILL_ACTIVE_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("REVOKED_DEVICE_CERTIFICATE_STILL_ACTIVE_CHECK")) {
+            translation.setRevokedDeviceCertificateStillActiveCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("REVOKED_DEVICE_CERTIFICATE_STILL_ACTIVE_CHECK").enabled()).build());
+        }
+        if (iotMap.containsKey("UNAUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK")) {
+            translation.setUnauthenticatedCognitoRoleOverlyPermissiveCheck(
+                    AuditCheckConfiguration.builder().enabled(
+                            iotMap.get("UNAUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK").enabled()).build());
+        }
 
-        return checkConfigurationMap
-                .entrySet()
-                .stream()
-                .filter(e -> e.getValue().enabled())
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toSet());
+        return translation;
     }
 
     static Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget>
     translateNotificationsFromCfnToIot(ResourceModel model) {
 
-        if (model.getAuditNotificationTargetConfigurations() == null) {
+        AuditNotificationTargetConfigurations cfnConfigurations = model.getAuditNotificationTargetConfigurations();
+        if (cfnConfigurations == null) {
             return Collections.emptyMap();
         }
-        return model.getAuditNotificationTargetConfigurations()
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> translateNotificationTargetFromCfnToIot(e.getValue())));
+
+        Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget> iotMap = new HashMap<>();
+        if (cfnConfigurations.getSns() != null) {
+            iotMap.put("SNS", translateNotificationTargetFromCfnToIot(cfnConfigurations.getSns()));
+        }
+
+        return iotMap;
     }
 
     private static software.amazon.awssdk.services.iot.model.AuditNotificationTarget
@@ -126,20 +239,24 @@ public class Translator {
                 .build();
     }
 
-    static Map<String, AuditNotificationTarget> translateNotificationsFromIotToCfn(
+    static AuditNotificationTargetConfigurations translateNotificationsFromIotToCfn(
             Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget> iotMap) {
 
-        if (iotMap == null) {
-            return Collections.emptyMap();
+        if (CollectionUtils.isNullOrEmpty(iotMap) || !iotMap.containsKey("SNS")) {
+            return null;
         }
 
-        return iotMap.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> AuditNotificationTarget.builder()
-                                .targetArn(e.getValue().targetArn())
-                                .roleArn(e.getValue().roleArn())
-                                .enabled(e.getValue().enabled())
-                                .build()));
+        return AuditNotificationTargetConfigurations.builder()
+                .sns(translateNotificationTargetFromIotToCfn(iotMap.get("SNS")))
+                .build();
+    }
+
+    private static AuditNotificationTarget translateNotificationTargetFromIotToCfn(
+            software.amazon.awssdk.services.iot.model.AuditNotificationTarget target) {
+        return AuditNotificationTarget.builder()
+                .targetArn(target.targetArn())
+                .roleArn(target.roleArn())
+                .enabled(target.enabled())
+                .build();
     }
 }

--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/Translator.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/Translator.java
@@ -1,9 +1,5 @@
 package com.amazonaws.iot.accountauditconfiguration;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.services.iot.model.InternalFailureException;
 import software.amazon.awssdk.services.iot.model.InvalidRequestException;
@@ -14,6 +10,10 @@ import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Translator {
 
@@ -61,11 +61,13 @@ public class Translator {
 
     static Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> translateChecksFromCfnToIot(ResourceModel model) {
 
-        // TODO: test empty template
 
         Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> iotMap = new HashMap<>();
 
         AuditCheckConfigurations auditCheckConfigurations = model.getAuditCheckConfigurations();
+        if (auditCheckConfigurations == null) {
+            return Collections.emptyMap();
+        }
 
         if (auditCheckConfigurations.getAuthenticatedCognitoRoleOverlyPermissiveCheck() != null) {
             iotMap.put("AUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK", translateCheckConfigurationFromCfnToIot(

--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/UpdateHandler.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/UpdateHandler.java
@@ -94,8 +94,9 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         Map<String, AuditCheckConfiguration> checkConfigurationsForUpdate = new HashMap<>();
         describeResponse.auditCheckConfigurations().keySet().forEach(k ->
                 checkConfigurationsForUpdate.put(k, AuditCheckConfiguration.builder().enabled(false).build()));
-        model.getAuditCheckConfigurations().forEach((key, value) ->
-                checkConfigurationsForUpdate.put(key, Translator.translateCheckConfigurationFromCfnToIot(value)));
+        Map<String, AuditCheckConfiguration> translatedCheckConfigurations =
+                Translator.translateChecksFromCfnToIot(model);
+        translatedCheckConfigurations.forEach(checkConfigurationsForUpdate::put);
         return checkConfigurationsForUpdate;
     }
 
@@ -114,5 +115,4 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                 .forEach(notificationTargetConfigurationsForUpdate::put);
         return notificationTargetConfigurationsForUpdate;
     }
-
 }

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/CreateHandlerTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/CreateHandlerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.iot.model.DescribeAccountAuditConfigurationRequest;
 import software.amazon.awssdk.services.iot.model.DescribeAccountAuditConfigurationResponse;
 import software.amazon.awssdk.services.iot.model.InvalidRequestException;
 import software.amazon.awssdk.services.iot.model.IotRequest;
@@ -21,8 +20,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ACCOUNT_ID;
@@ -32,9 +29,6 @@ import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NO
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_REQUEST;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ZERO_STATE;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ZERO_STATE_CHECKS;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DISABLED_IOT;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ENABLED_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ENABLED_IOT;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ROLE_ARN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.createCfnRequest;
@@ -48,7 +42,6 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest {
-
     Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration>
             CHECK_CONFIGURATION_FROM_EXPECTED_UPDATE_REQUEST = ImmutableMap.of(
             "LOGGING_DISABLED_CHECK", ENABLED_IOT,
@@ -72,7 +65,7 @@ public class CreateHandlerTest {
 
         ResourceModel model = ResourceModel.builder()
                 .accountId(ACCOUNT_ID)
-                .auditCheckConfigurations(AUDIT_CHECK_CONFIGURATIONS_V1_CFN)
+                .auditCheckConfigurations((AUDIT_CHECK_CONFIGURATIONS_V1_CFN))
                 .auditNotificationTargetConfigurations(AUDIT_NOTIFICATION_TARGET_CFN)
                 .roleArn(ROLE_ARN)
                 .build();
@@ -104,7 +97,7 @@ public class CreateHandlerTest {
     }
 
     @Test
-    public void handleRequest_DescribeShowsIdenticalConfig_ExpectSuccess_NoUpdateCall() {
+    public void handleRequest_DescribeShowsSameRoleArn_ExpectRAE() {
 
         ResourceModel model = ResourceModel.builder()
                 .accountId(ACCOUNT_ID)
@@ -117,22 +110,9 @@ public class CreateHandlerTest {
         when(proxy.injectCredentialsAndInvokeV2(eq(DESCRIBE_REQUEST), any()))
                 .thenReturn(DESCRIBE_RESPONSE_V1_STATE);
 
-        ProgressEvent<ResourceModel, CallbackContext> handlerResponse =
-                handler.handleRequest(proxy, cfnRequest, null, logger);
-
-        ArgumentCaptor<IotRequest> iotRequestCaptor = ArgumentCaptor.forClass(IotRequest.class);
-        verify(proxy).injectCredentialsAndInvokeV2(iotRequestCaptor.capture(), any());
-        assertThat(iotRequestCaptor.getAllValues()).isEqualTo(
-                Collections.singletonList(DescribeAccountAuditConfigurationRequest.builder().build()));
-
-        assertThat(handlerResponse).isNotNull();
-        assertThat(handlerResponse.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(handlerResponse.getCallbackContext()).isNull();
-        assertThat(handlerResponse.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(handlerResponse.getResourceModels()).isNull();
-        assertThat(handlerResponse.getMessage()).isNull();
-        assertThat(handlerResponse.getErrorCode()).isNull();
-        assertThat(handlerResponse.getResourceModel()).isEqualTo(model);
+        assertThatThrownBy(() ->
+                handler.handleRequest(proxy, cfnRequest, null, logger))
+                .isInstanceOf(CfnAlreadyExistsException.class);
     }
 
     @Test
@@ -154,98 +134,6 @@ public class CreateHandlerTest {
         assertThatThrownBy(() ->
                 handler.handleRequest(proxy, cfnRequest, null, logger))
                 .isInstanceOf(CfnAlreadyExistsException.class);
-    }
-
-    @Test
-    public void areCheckConfigurationsEquivalent_DescribeHasMoreDisabledChecks_ExpectTrue() {
-
-        ResourceModel model = ResourceModel.builder()
-                .accountId(ACCOUNT_ID)
-                .auditCheckConfigurations(AUDIT_CHECK_CONFIGURATIONS_V1_CFN)
-                .auditNotificationTargetConfigurations(AUDIT_NOTIFICATION_TARGET_CFN)
-                .roleArn(ROLE_ARN)
-                .build();
-        Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> mapWithMoreChecksDisabled =
-                new HashMap<>(CHECK_CONFIGURATION_FROM_EXPECTED_UPDATE_REQUEST);
-        mapWithMoreChecksDisabled.put("CONFLICTING_CLIENT_IDS_CHECK", DISABLED_IOT);
-        DescribeAccountAuditConfigurationResponse describeResponse =
-                DESCRIBE_RESPONSE_V1_STATE.toBuilder()
-                        .auditCheckConfigurations(mapWithMoreChecksDisabled)
-                        .build();
-
-        assertThat(handler.areCheckConfigurationsEquivalent(model, describeResponse)).isTrue();
-    }
-
-    @Test
-    public void areCheckConfigurationsEquivalent_DescribeHasOneMoreEnabled_ExpectFalse() {
-
-        ResourceModel model = ResourceModel.builder()
-                .accountId(ACCOUNT_ID)
-                .auditCheckConfigurations(AUDIT_CHECK_CONFIGURATIONS_V1_CFN)
-                .auditNotificationTargetConfigurations(AUDIT_NOTIFICATION_TARGET_CFN)
-                .roleArn(ROLE_ARN)
-                .build();
-        Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> mapWithMoreChecksEnabled =
-                new HashMap<>(DESCRIBE_RESPONSE_ZERO_STATE_CHECKS);
-        mapWithMoreChecksEnabled.put("CONFLICTING_CLIENT_IDS_CHECK", ENABLED_IOT);
-        DescribeAccountAuditConfigurationResponse describeResponse =
-                DESCRIBE_RESPONSE_V1_STATE.toBuilder()
-                        .auditCheckConfigurations(mapWithMoreChecksEnabled)
-                        .build();
-
-        assertThat(handler.areCheckConfigurationsEquivalent(model, describeResponse)).isFalse();
-    }
-
-    @Test
-    public void areCheckConfigurationsEquivalent_ModelHasOneMoreEnabled_ExpectFalse() {
-
-        Map<String, AuditCheckConfiguration> mapWithOneMoreCheckEnabled =
-                new HashMap<>(AUDIT_CHECK_CONFIGURATIONS_V1_CFN);
-        mapWithOneMoreCheckEnabled.put("CA_CERTIFICATE_KEY_QUALITY_CHECK", ENABLED_CFN);
-        ResourceModel model = ResourceModel.builder()
-                .accountId(ACCOUNT_ID)
-                .auditCheckConfigurations(mapWithOneMoreCheckEnabled)
-                .auditNotificationTargetConfigurations(AUDIT_NOTIFICATION_TARGET_CFN)
-                .roleArn(ROLE_ARN)
-                .build();
-
-        assertThat(handler.areCheckConfigurationsEquivalent(model, DESCRIBE_RESPONSE_V1_STATE)).isFalse();
-    }
-
-    @Test
-    public void areNotificationTargetsEquivalent_DescribeHasNull_ExpectFalse() {
-        ResourceModel model = ResourceModel.builder()
-                .accountId(ACCOUNT_ID)
-                .auditCheckConfigurations(AUDIT_CHECK_CONFIGURATIONS_V1_CFN)
-                .auditNotificationTargetConfigurations(AUDIT_NOTIFICATION_TARGET_CFN)
-                .roleArn(ROLE_ARN)
-                .build();
-        assertThat(handler.areNotificationTargetsEquivalent(model, DESCRIBE_RESPONSE_ZERO_STATE)).isFalse();
-    }
-
-    @Test
-    public void areNotificationTargetsEquivalent_ModelHasNull_ExpectFalse() {
-        ResourceModel model = ResourceModel.builder()
-                .accountId(ACCOUNT_ID)
-                .auditCheckConfigurations(AUDIT_CHECK_CONFIGURATIONS_V1_CFN)
-                .auditNotificationTargetConfigurations(null)
-                .roleArn(ROLE_ARN)
-                .build();
-        assertThat(handler.areNotificationTargetsEquivalent(model, DESCRIBE_RESPONSE_V1_STATE)).isFalse();
-    }
-
-    @Test
-    public void areNotificationTargetsEquivalent_DifferentTargetArns_ExpectFalse() {
-        Map<String, AuditNotificationTarget> mapWithDifferentTargetArn = ImmutableMap.of(
-                "SNS", AuditNotificationTarget.builder().enabled(true)
-                        .targetArn("differentTargetArn").roleArn(ROLE_ARN).build());
-        ResourceModel model = ResourceModel.builder()
-                .accountId(ACCOUNT_ID)
-                .auditCheckConfigurations(AUDIT_CHECK_CONFIGURATIONS_V1_CFN)
-                .auditNotificationTargetConfigurations(mapWithDifferentTargetArn)
-                .roleArn(ROLE_ARN)
-                .build();
-        assertThat(handler.areNotificationTargetsEquivalent(model, DESCRIBE_RESPONSE_V1_STATE)).isFalse();
     }
 
     @Test

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/CreateHandlerTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/CreateHandlerTest.java
@@ -65,7 +65,7 @@ public class CreateHandlerTest {
 
         ResourceModel model = ResourceModel.builder()
                 .accountId(ACCOUNT_ID)
-                .auditCheckConfigurations((AUDIT_CHECK_CONFIGURATIONS_V1_CFN))
+                .auditCheckConfigurations(AUDIT_CHECK_CONFIGURATIONS_V1_CFN)
                 .auditNotificationTargetConfigurations(AUDIT_NOTIFICATION_TARGET_CFN)
                 .roleArn(ROLE_ARN)
                 .build();
@@ -96,6 +96,7 @@ public class CreateHandlerTest {
         assertThat(handlerResponse.getResourceModel()).isEqualTo(model);
     }
 
+    // CreateHandler throws RAE as soon as it sees a RoleArn already present, no matter whether it's the same or not.
     @Test
     public void handleRequest_DescribeShowsSameRoleArn_ExpectRAE() {
 
@@ -115,6 +116,7 @@ public class CreateHandlerTest {
                 .isInstanceOf(CfnAlreadyExistsException.class);
     }
 
+    // CreateHandler throws RAE as soon as it sees a RoleArn already present, no matter whether it's the same or not.
     @Test
     public void handleRequest_DescribeShowsDifferentRoleArn_ExpectRAE() {
 

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/DeleteHandlerTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/DeleteHandlerTest.java
@@ -32,7 +32,6 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest {
-
     private static final ResourceModel MODEL_FOR_REQUEST = ResourceModel.builder()
             .accountId(ACCOUNT_ID)
             .roleArn("doesn't matter")

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/ListHandlerTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/ListHandlerTest.java
@@ -1,26 +1,11 @@
 package com.amazonaws.iot.accountauditconfiguration;
 
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ACCOUNT_ID;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_REQUEST;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ZERO_STATE;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.createCfnRequest;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.iot.model.InternalFailureException;
-import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -28,9 +13,21 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.Collections;
+import java.util.List;
+
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ACCOUNT_ID;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_REQUEST;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ZERO_STATE;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.createCfnRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest {
-
     @Mock
     private AmazonWebServicesClientProxy proxy;
 

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/ReadHandlerTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/ReadHandlerTest.java
@@ -1,5 +1,18 @@
 package com.amazonaws.iot.accountauditconfiguration;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.iot.model.UnauthorizedException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ACCOUNT_ID;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_CHECK_CONFIGURATIONS_V1_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_CFN;
@@ -11,32 +24,12 @@ import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ROLE_ARN
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.TARGET_ARN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.createCfnRequest;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.services.iot.model.UnauthorizedException;
-import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest {
-
     @Mock
     private AmazonWebServicesClientProxy proxy;
 
@@ -74,8 +67,9 @@ public class ReadHandlerTest {
         assertThat(actualResult.getMessage()).isNull();
         assertThat(actualResult.getErrorCode()).isNull();
 
-        Map<String, AuditNotificationTarget> expectedNotificationConfigurations = ImmutableMap.of("SNS",
-                AuditNotificationTarget.builder().targetArn(TARGET_ARN).enabled(true).roleArn(ROLE_ARN).build());
+        AuditNotificationTargetConfigurations expectedNotificationConfigurations =
+                AuditNotificationTargetConfigurations.builder()
+                        .sns(AuditNotificationTarget.builder().targetArn(TARGET_ARN).enabled(true).roleArn(ROLE_ARN).build()).build();
         ResourceModel expectedResult = ResourceModel.builder()
                 .accountId(ACCOUNT_ID)
                 .auditCheckConfigurations(DESCRIBE_RESPONSE_V1_STATE_CFN)

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TestConstants.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TestConstants.java
@@ -1,12 +1,11 @@
 package com.amazonaws.iot.accountauditconfiguration;
 
-import java.util.Map;
-
 import com.google.common.collect.ImmutableMap;
-
 import software.amazon.awssdk.services.iot.model.DescribeAccountAuditConfigurationRequest;
 import software.amazon.awssdk.services.iot.model.DescribeAccountAuditConfigurationResponse;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.Map;
 
 public class TestConstants {
     static final String ACCOUNT_ID = "123456789012";
@@ -28,9 +27,9 @@ public class TestConstants {
             .build();
     static final AuditNotificationTargetConfigurations AUDIT_NOTIFICATION_TARGET_CFN =
             AuditNotificationTargetConfigurations.builder()
-            .sns(AuditNotificationTarget.builder().enabled(true)
-                    .targetArn(TARGET_ARN).roleArn(ROLE_ARN).build())
-            .build();
+                    .sns(AuditNotificationTarget.builder().enabled(true)
+                            .targetArn(TARGET_ARN).roleArn(ROLE_ARN).build())
+                    .build();
     static final AuditNotificationTargetConfigurations AUDIT_NOTIFICATION_TARGET_V2_CFN =
             AuditNotificationTargetConfigurations.builder().sns(AuditNotificationTarget.builder().enabled(true).targetArn(TARGET_ARN + "_v2").roleArn(ROLE_ARN).build()).build();
 
@@ -41,6 +40,12 @@ public class TestConstants {
     static final Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget>
             AUDIT_NOTIFICATION_TARGET_IOT = ImmutableMap.of(
             "SNS", getNotificationBuilderIot().enabled(true)
+                    .targetArn(TARGET_ARN).roleArn(ROLE_ARN).build());
+    static final Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget>
+            AUDIT_NOTIFICATION_TARGET_IOT_NON_EXISTENT_KEY = ImmutableMap.of(
+            "SNS", getNotificationBuilderIot().enabled(true)
+                    .targetArn(TARGET_ARN).roleArn(ROLE_ARN).build(),
+            "NON_EXISTENT_KEY", getNotificationBuilderIot().enabled(true)
                     .targetArn(TARGET_ARN).roleArn(ROLE_ARN).build());
     static final Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget>
             AUDIT_NOTIFICATION_TARGET_V2_IOT = ImmutableMap.of(
@@ -79,6 +84,50 @@ public class TestConstants {
             .caCertificateKeyQualityCheck(DISABLED_CFN)
             .deviceCertificateExpiringCheck(DISABLED_CFN)
             .build();
+
+    static final ImmutableMap<String,software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> ALL_CHECKS_MAP_IOT =
+            ImmutableMap.<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration>builder()
+                    .put("LOGGING_DISABLED_CHECK", ENABLED_IOT)
+                    .put("CA_CERTIFICATE_EXPIRING_CHECK", ENABLED_IOT)
+                    .put("CA_CERTIFICATE_KEY_QUALITY_CHECK", DISABLED_IOT)
+                    .put("REVOKED_CA_CERTIFICATE_STILL_ACTIVE_CHECK", DISABLED_IOT)
+                    .put("DEVICE_CERTIFICATE_EXPIRING_CHECK", DISABLED_IOT)
+                    .put("DEVICE_CERTIFICATE_SHARED_CHECK", DISABLED_IOT)
+                    .put("DEVICE_CERTIFICATE_KEY_QUALITY_CHECK", DISABLED_IOT)
+                    .put("UNAUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK", DISABLED_IOT)
+                    .put("AUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK", DISABLED_IOT)
+                    .put("IOT_POLICY_OVERLY_PERMISSIVE_CHECK", DISABLED_IOT)
+                    .put("IOT_ROLE_ALIAS_OVERLY_PERMISSIVE_CHECK", DISABLED_IOT)
+                    .put("IOT_ROLE_ALIAS_ALLOWS_ACCESS_TO_UNUSED_SERVICES_CHECK", DISABLED_IOT)
+                    .put("CONFLICTING_CLIENT_IDS_CHECK", DISABLED_IOT)
+                    .put("REVOKED_DEVICE_CERTIFICATE_STILL_ACTIVE_CHECK", DISABLED_IOT)
+                    .build();
+
+    static final DescribeAccountAuditConfigurationResponse DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT =
+            DescribeAccountAuditConfigurationResponse.builder()
+                    .auditCheckConfigurations(ALL_CHECKS_MAP_IOT)
+                    .auditNotificationTargetConfigurationsWithStrings(AUDIT_NOTIFICATION_TARGET_IOT)
+                    .roleArn(ROLE_ARN)
+                    .build();
+
+    static final AuditCheckConfigurations DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT_CFN = AuditCheckConfigurations.builder()
+            .loggingDisabledCheck(ENABLED_CFN)
+            .caCertificateExpiringCheck(ENABLED_CFN)
+            .conflictingClientIdsCheck(DISABLED_CFN)
+            .caCertificateKeyQualityCheck(DISABLED_CFN)
+            .deviceCertificateExpiringCheck(DISABLED_CFN)
+            .authenticatedCognitoRoleOverlyPermissiveCheck(DISABLED_CFN)
+            .deviceCertificateKeyQualityCheck(DISABLED_CFN)
+            .deviceCertificateSharedCheck(DISABLED_CFN)
+            .iotPolicyOverlyPermissiveCheck(DISABLED_CFN)
+            .iotRoleAliasAllowsAccessToUnusedServicesCheck(DISABLED_CFN)
+            .iotRoleAliasOverlyPermissiveCheck(DISABLED_CFN)
+            .revokedCaCertificateStillActiveCheck(DISABLED_CFN)
+            .revokedDeviceCertificateStillActiveCheck(DISABLED_CFN)
+            .unauthenticatedCognitoRoleOverlyPermissiveCheck(DISABLED_CFN)
+            .build();
+
+
     static final DescribeAccountAuditConfigurationResponse DESCRIBE_RESPONSE_V1_STATE_WITH_NON_EXISTENT_KEY =
             DescribeAccountAuditConfigurationResponse.builder()
                     .auditCheckConfigurations(ImmutableMap.of(
@@ -92,11 +141,11 @@ public class TestConstants {
                     .build();
     static final AuditCheckConfigurations DESCRIBE_RESPONSE_V1_STATE_NON_EXISTENT_KEY_INGNORED_CFN =
             AuditCheckConfigurations.builder()
-            .loggingDisabledCheck(ENABLED_CFN)
-            .caCertificateExpiringCheck(ENABLED_CFN)
-            .conflictingClientIdsCheck(DISABLED_CFN)
-            .caCertificateKeyQualityCheck(DISABLED_CFN)
-            .build();
+                    .loggingDisabledCheck(ENABLED_CFN)
+                    .caCertificateExpiringCheck(ENABLED_CFN)
+                    .conflictingClientIdsCheck(DISABLED_CFN)
+                    .caCertificateKeyQualityCheck(DISABLED_CFN)
+                    .build();
     static software.amazon.awssdk.services.iot.model.AuditNotificationTarget.Builder
     getNotificationBuilderIot() {
         return software.amazon.awssdk.services.iot.model.AuditNotificationTarget.builder();

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TestConstants.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TestConstants.java
@@ -5,12 +5,28 @@ import software.amazon.awssdk.services.iot.model.DescribeAccountAuditConfigurati
 import software.amazon.awssdk.services.iot.model.DescribeAccountAuditConfigurationResponse;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 public class TestConstants {
     static final String ACCOUNT_ID = "123456789012";
     static final String ROLE_ARN = "testRoleArn";
     static final String TARGET_ARN = "testTargetArn";
+    static final List<String> ALL_CHECKS = Arrays.asList("LOGGING_DISABLED_CHECK",
+            "CA_CERTIFICATE_EXPIRING_CHECK",
+            "CA_CERTIFICATE_KEY_QUALITY_CHECK",
+            "REVOKED_CA_CERTIFICATE_STILL_ACTIVE_CHECK",
+            "DEVICE_CERTIFICATE_EXPIRING_CHECK",
+            "DEVICE_CERTIFICATE_SHARED_CHECK",
+            "DEVICE_CERTIFICATE_KEY_QUALITY_CHECK",
+            "UNAUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK",
+            "AUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK",
+            "IOT_POLICY_OVERLY_PERMISSIVE_CHECK",
+            "IOT_ROLE_ALIAS_OVERLY_PERMISSIVE_CHECK",
+            "IOT_ROLE_ALIAS_ALLOWS_ACCESS_TO_UNUSED_SERVICES_CHECK",
+            "CONFLICTING_CLIENT_IDS_CHECK",
+            "REVOKED_DEVICE_CERTIFICATE_STILL_ACTIVE_CHECK");
 
     static final AuditCheckConfiguration ENABLED_CFN =
             AuditCheckConfiguration.builder().enabled(true).build();
@@ -85,49 +101,6 @@ public class TestConstants {
             .deviceCertificateExpiringCheck(DISABLED_CFN)
             .build();
 
-    static final ImmutableMap<String,software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> ALL_CHECKS_MAP_IOT =
-            ImmutableMap.<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration>builder()
-                    .put("LOGGING_DISABLED_CHECK", ENABLED_IOT)
-                    .put("CA_CERTIFICATE_EXPIRING_CHECK", ENABLED_IOT)
-                    .put("CA_CERTIFICATE_KEY_QUALITY_CHECK", DISABLED_IOT)
-                    .put("REVOKED_CA_CERTIFICATE_STILL_ACTIVE_CHECK", DISABLED_IOT)
-                    .put("DEVICE_CERTIFICATE_EXPIRING_CHECK", DISABLED_IOT)
-                    .put("DEVICE_CERTIFICATE_SHARED_CHECK", DISABLED_IOT)
-                    .put("DEVICE_CERTIFICATE_KEY_QUALITY_CHECK", DISABLED_IOT)
-                    .put("UNAUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK", DISABLED_IOT)
-                    .put("AUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK", DISABLED_IOT)
-                    .put("IOT_POLICY_OVERLY_PERMISSIVE_CHECK", DISABLED_IOT)
-                    .put("IOT_ROLE_ALIAS_OVERLY_PERMISSIVE_CHECK", DISABLED_IOT)
-                    .put("IOT_ROLE_ALIAS_ALLOWS_ACCESS_TO_UNUSED_SERVICES_CHECK", DISABLED_IOT)
-                    .put("CONFLICTING_CLIENT_IDS_CHECK", DISABLED_IOT)
-                    .put("REVOKED_DEVICE_CERTIFICATE_STILL_ACTIVE_CHECK", DISABLED_IOT)
-                    .build();
-
-    static final DescribeAccountAuditConfigurationResponse DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT =
-            DescribeAccountAuditConfigurationResponse.builder()
-                    .auditCheckConfigurations(ALL_CHECKS_MAP_IOT)
-                    .auditNotificationTargetConfigurationsWithStrings(AUDIT_NOTIFICATION_TARGET_IOT)
-                    .roleArn(ROLE_ARN)
-                    .build();
-
-    static final AuditCheckConfigurations DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT_CFN = AuditCheckConfigurations.builder()
-            .loggingDisabledCheck(ENABLED_CFN)
-            .caCertificateExpiringCheck(ENABLED_CFN)
-            .conflictingClientIdsCheck(DISABLED_CFN)
-            .caCertificateKeyQualityCheck(DISABLED_CFN)
-            .deviceCertificateExpiringCheck(DISABLED_CFN)
-            .authenticatedCognitoRoleOverlyPermissiveCheck(DISABLED_CFN)
-            .deviceCertificateKeyQualityCheck(DISABLED_CFN)
-            .deviceCertificateSharedCheck(DISABLED_CFN)
-            .iotPolicyOverlyPermissiveCheck(DISABLED_CFN)
-            .iotRoleAliasAllowsAccessToUnusedServicesCheck(DISABLED_CFN)
-            .iotRoleAliasOverlyPermissiveCheck(DISABLED_CFN)
-            .revokedCaCertificateStillActiveCheck(DISABLED_CFN)
-            .revokedDeviceCertificateStillActiveCheck(DISABLED_CFN)
-            .unauthenticatedCognitoRoleOverlyPermissiveCheck(DISABLED_CFN)
-            .build();
-
-
     static final DescribeAccountAuditConfigurationResponse DESCRIBE_RESPONSE_V1_STATE_WITH_NON_EXISTENT_KEY =
             DescribeAccountAuditConfigurationResponse.builder()
                     .auditCheckConfigurations(ImmutableMap.of(
@@ -156,6 +129,42 @@ public class TestConstants {
                 .desiredResourceState(model)
                 .logicalResourceIdentifier("doesn't matter")
                 .awsAccountId(ACCOUNT_ID)
+                .build();
+    }
+
+    static DescribeAccountAuditConfigurationResponse getDescribeAccountAuditConfigurationResponse(List<String> checksToEnable) {
+        ImmutableMap.Builder<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> builder = new ImmutableMap.Builder<>();
+
+        for (String check : ALL_CHECKS) {
+            if (checksToEnable.contains(check)) {
+                builder.put(check, ENABLED_IOT);
+            } else {
+                builder.put(check, DISABLED_IOT);
+            }
+        }
+        return DescribeAccountAuditConfigurationResponse.builder()
+                .auditCheckConfigurations(builder.build())
+                .auditNotificationTargetConfigurationsWithStrings(AUDIT_NOTIFICATION_TARGET_IOT)
+                .roleArn(ROLE_ARN)
+                .build();
+    }
+
+    static AuditCheckConfigurations getAuditCheckConfigurationsAllChecksDisabledCfn() {
+        return AuditCheckConfigurations.builder()
+                .loggingDisabledCheck(DISABLED_CFN)
+                .caCertificateExpiringCheck(DISABLED_CFN)
+                .conflictingClientIdsCheck(DISABLED_CFN)
+                .caCertificateKeyQualityCheck(DISABLED_CFN)
+                .deviceCertificateExpiringCheck(DISABLED_CFN)
+                .authenticatedCognitoRoleOverlyPermissiveCheck(DISABLED_CFN)
+                .deviceCertificateKeyQualityCheck(DISABLED_CFN)
+                .deviceCertificateSharedCheck(DISABLED_CFN)
+                .iotPolicyOverlyPermissiveCheck(DISABLED_CFN)
+                .iotRoleAliasAllowsAccessToUnusedServicesCheck(DISABLED_CFN)
+                .iotRoleAliasOverlyPermissiveCheck(DISABLED_CFN)
+                .revokedCaCertificateStillActiveCheck(DISABLED_CFN)
+                .revokedDeviceCertificateStillActiveCheck(DISABLED_CFN)
+                .unauthenticatedCognitoRoleOverlyPermissiveCheck(DISABLED_CFN)
                 .build();
     }
 }

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TestConstants.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TestConstants.java
@@ -9,7 +9,6 @@ import software.amazon.awssdk.services.iot.model.DescribeAccountAuditConfigurati
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class TestConstants {
-
     static final String ACCOUNT_ID = "123456789012";
     static final String ROLE_ARN = "testRoleArn";
     static final String TARGET_ARN = "testTargetArn";
@@ -18,19 +17,22 @@ public class TestConstants {
             AuditCheckConfiguration.builder().enabled(true).build();
     static final AuditCheckConfiguration DISABLED_CFN =
             AuditCheckConfiguration.builder().enabled(false).build();
-    static final Map<String, AuditCheckConfiguration> AUDIT_CHECK_CONFIGURATIONS_V1_CFN = ImmutableMap.of(
-            "LOGGING_DISABLED_CHECK", ENABLED_CFN,
-            "CA_CERTIFICATE_EXPIRING_CHECK", ENABLED_CFN);
-    static final Map<String, AuditCheckConfiguration> AUDIT_CHECK_CONFIGURATIONS_V2_CFN = ImmutableMap.of(
-            "LOGGING_DISABLED_CHECK", ENABLED_CFN,
-            "DEVICE_CERTIFICATE_EXPIRING_CHECK", ENABLED_CFN,
-            "CA_CERTIFICATE_EXPIRING_CHECK", DISABLED_CFN);
-    static final Map<String, AuditNotificationTarget> AUDIT_NOTIFICATION_TARGET_CFN = ImmutableMap.of(
-            "SNS", AuditNotificationTarget.builder().enabled(true)
-                    .targetArn(TARGET_ARN).roleArn(ROLE_ARN).build());
-    static final Map<String, AuditNotificationTarget> AUDIT_NOTIFICATION_TARGET_V2_CFN = ImmutableMap.of(
-            "SNS", AuditNotificationTarget.builder().enabled(true)
-                    .targetArn(TARGET_ARN + "_v2").roleArn(ROLE_ARN).build());
+    static final AuditCheckConfigurations AUDIT_CHECK_CONFIGURATIONS_V1_CFN = AuditCheckConfigurations.builder()
+            .loggingDisabledCheck(AuditCheckConfiguration.builder().enabled(true).build())
+            .caCertificateExpiringCheck(AuditCheckConfiguration.builder().enabled(true).build())
+            .build();
+    static final AuditCheckConfigurations AUDIT_CHECK_CONFIGURATIONS_V2_CFN = AuditCheckConfigurations.builder()
+            .loggingDisabledCheck(AuditCheckConfiguration.builder().enabled(true).build())
+            .deviceCertificateExpiringCheck(AuditCheckConfiguration.builder().enabled(true).build())
+            .caCertificateExpiringCheck(AuditCheckConfiguration.builder().enabled(false).build())
+            .build();
+    static final AuditNotificationTargetConfigurations AUDIT_NOTIFICATION_TARGET_CFN =
+            AuditNotificationTargetConfigurations.builder()
+            .sns(AuditNotificationTarget.builder().enabled(true)
+                    .targetArn(TARGET_ARN).roleArn(ROLE_ARN).build())
+            .build();
+    static final AuditNotificationTargetConfigurations AUDIT_NOTIFICATION_TARGET_V2_CFN =
+            AuditNotificationTargetConfigurations.builder().sns(AuditNotificationTarget.builder().enabled(true).targetArn(TARGET_ARN + "_v2").roleArn(ROLE_ARN).build()).build();
 
     static final software.amazon.awssdk.services.iot.model.AuditCheckConfiguration ENABLED_IOT =
             software.amazon.awssdk.services.iot.model.AuditCheckConfiguration.builder().enabled(true).build();
@@ -70,13 +72,31 @@ public class TestConstants {
                     .auditNotificationTargetConfigurationsWithStrings(AUDIT_NOTIFICATION_TARGET_IOT)
                     .roleArn(ROLE_ARN)
                     .build();
-    static final Map<String, AuditCheckConfiguration> DESCRIBE_RESPONSE_V1_STATE_CFN = ImmutableMap.of(
-            "LOGGING_DISABLED_CHECK", ENABLED_CFN,
-            "CA_CERTIFICATE_EXPIRING_CHECK", ENABLED_CFN,
-            "CONFLICTING_CLIENT_IDS_CHECK", DISABLED_CFN,
-            "CA_CERTIFICATE_KEY_QUALITY_CHECK", DISABLED_CFN,
-            "DEVICE_CERTIFICATE_EXPIRING_CHECK", DISABLED_CFN);
-
+    static final AuditCheckConfigurations DESCRIBE_RESPONSE_V1_STATE_CFN = AuditCheckConfigurations.builder()
+            .loggingDisabledCheck(ENABLED_CFN)
+            .caCertificateExpiringCheck(ENABLED_CFN)
+            .conflictingClientIdsCheck(DISABLED_CFN)
+            .caCertificateKeyQualityCheck(DISABLED_CFN)
+            .deviceCertificateExpiringCheck(DISABLED_CFN)
+            .build();
+    static final DescribeAccountAuditConfigurationResponse DESCRIBE_RESPONSE_V1_STATE_WITH_NON_EXISTENT_KEY =
+            DescribeAccountAuditConfigurationResponse.builder()
+                    .auditCheckConfigurations(ImmutableMap.of(
+                            "LOGGING_DISABLED_CHECK", ENABLED_IOT,
+                            "CA_CERTIFICATE_EXPIRING_CHECK", ENABLED_IOT,
+                            "CONFLICTING_CLIENT_IDS_CHECK", DISABLED_IOT,
+                            "CA_CERTIFICATE_KEY_QUALITY_CHECK", DISABLED_IOT,
+                            "NON_EXISTENT_KEY", DISABLED_IOT))
+                    .auditNotificationTargetConfigurationsWithStrings(AUDIT_NOTIFICATION_TARGET_IOT)
+                    .roleArn(ROLE_ARN)
+                    .build();
+    static final AuditCheckConfigurations DESCRIBE_RESPONSE_V1_STATE_NON_EXISTENT_KEY_INGNORED_CFN =
+            AuditCheckConfigurations.builder()
+            .loggingDisabledCheck(ENABLED_CFN)
+            .caCertificateExpiringCheck(ENABLED_CFN)
+            .conflictingClientIdsCheck(DISABLED_CFN)
+            .caCertificateKeyQualityCheck(DISABLED_CFN)
+            .build();
     static software.amazon.awssdk.services.iot.model.AuditNotificationTarget.Builder
     getNotificationBuilderIot() {
         return software.amazon.awssdk.services.iot.model.AuditNotificationTarget.builder();

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TranslatorTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TranslatorTest.java
@@ -6,17 +6,19 @@ import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_IOT;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_IOT_NON_EXISTENT_KEY;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE_NON_EXISTENT_KEY_INGNORED_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE_WITH_NON_EXISTENT_KEY;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ENABLED_CFN;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.getAuditCheckConfigurationsAllChecksDisabledCfn;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.getDescribeAccountAuditConfigurationResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -98,17 +100,140 @@ public class TranslatorTest {
     @Test
     void translateChecksFromCfnToIot_AllChecksArePresent_VerifyTranslation() {
         Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> expectedResult =
-                DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT.auditCheckConfigurations();
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("LOGGING_DISABLED_CHECK", "CA_CERTIFICATE_EXPIRING_CHECK"))
+                        .auditCheckConfigurations();
+        AuditCheckConfigurations auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setLoggingDisabledCheck(ENABLED_CFN);
+        auditCheckConfigurations.setCaCertificateExpiringCheck(ENABLED_CFN);
         ResourceModel input = ResourceModel.builder()
-                .auditCheckConfigurations(DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT_CFN).build();
+                .auditCheckConfigurations(auditCheckConfigurations).build();
         assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
     }
 
     @Test
     void translateChecksFromIotToCfn_AllChecksArePresent() {
         Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> input =
-                DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT.auditCheckConfigurations();
-        assertThat(Translator.translateChecksFromIotToCfn(input)).isEqualTo(DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT_CFN);
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("LOGGING_DISABLED_CHECK", "CA_CERTIFICATE_EXPIRING_CHECK"))
+                        .auditCheckConfigurations();
+        AuditCheckConfigurations auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setLoggingDisabledCheck(ENABLED_CFN);
+        auditCheckConfigurations.setCaCertificateExpiringCheck(ENABLED_CFN);
+        assertThat(Translator.translateChecksFromIotToCfn(input)).isEqualTo(auditCheckConfigurations);
+    }
+
+    @Test
+    void translateChecksFromCfnToIot_OneCheckEnabledRestDisabled_VerifyTranslation() {
+        Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("LOGGING_DISABLED_CHECK")).auditCheckConfigurations();
+        AuditCheckConfigurations auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setLoggingDisabledCheck(ENABLED_CFN);
+        ResourceModel input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("CA_CERTIFICATE_EXPIRING_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setCaCertificateExpiringCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("CA_CERTIFICATE_KEY_QUALITY_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setCaCertificateKeyQualityCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("REVOKED_CA_CERTIFICATE_STILL_ACTIVE_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setRevokedCaCertificateStillActiveCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("DEVICE_CERTIFICATE_EXPIRING_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setDeviceCertificateExpiringCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("DEVICE_CERTIFICATE_SHARED_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setDeviceCertificateSharedCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("DEVICE_CERTIFICATE_KEY_QUALITY_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setDeviceCertificateKeyQualityCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("UNAUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setUnauthenticatedCognitoRoleOverlyPermissiveCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("AUTHENTICATED_COGNITO_ROLE_OVERLY_PERMISSIVE_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setAuthenticatedCognitoRoleOverlyPermissiveCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("IOT_POLICY_OVERLY_PERMISSIVE_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setIotPolicyOverlyPermissiveCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("IOT_ROLE_ALIAS_OVERLY_PERMISSIVE_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setIotRoleAliasOverlyPermissiveCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("IOT_ROLE_ALIAS_ALLOWS_ACCESS_TO_UNUSED_SERVICES_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setIotRoleAliasAllowsAccessToUnusedServicesCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("CONFLICTING_CLIENT_IDS_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setConflictingClientIdsCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+
+        expectedResult =
+                getDescribeAccountAuditConfigurationResponse(Arrays.asList("REVOKED_DEVICE_CERTIFICATE_STILL_ACTIVE_CHECK")).auditCheckConfigurations();
+        auditCheckConfigurations = getAuditCheckConfigurationsAllChecksDisabledCfn();
+        auditCheckConfigurations.setRevokedDeviceCertificateStillActiveCheck(ENABLED_CFN);
+        input = ResourceModel.builder()
+                .auditCheckConfigurations(auditCheckConfigurations).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
     }
 
 }

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TranslatorTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TranslatorTest.java
@@ -1,21 +1,24 @@
 package com.amazonaws.iot.accountauditconfiguration;
 
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.iot.model.InvalidRequestException;
+import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.Logger;
+
+import java.util.Map;
+
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_IOT;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_IOT_NON_EXISTENT_KEY;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE_NON_EXISTENT_KEY_INGNORED_CFN;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE_WITH_NON_EXISTENT_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-
-import java.util.Map;
-
-import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.iot.model.InvalidRequestException;
-import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
-import software.amazon.cloudformation.proxy.Logger;
 
 public class TranslatorTest {
     @Test
@@ -76,7 +79,36 @@ public class TranslatorTest {
     }
 
     @Test
-    void translateNotificationsFromIotToCfn_NullIn_EmptyOut() {
+    void translateNotificationsFromIotToCfn_NullIn_NullOut() {
         assertThat(Translator.translateNotificationsFromIotToCfn(null)).isNull();
     }
+
+    @Test
+    void translateNotificationsFromIotToCfn_NonExistentKeyFromIot_VerifyIgnoredInTranslation() {
+        assertThat(Translator.translateNotificationsFromIotToCfn(AUDIT_NOTIFICATION_TARGET_IOT_NON_EXISTENT_KEY))
+                .isEqualTo(AUDIT_NOTIFICATION_TARGET_CFN);
+    }
+
+    @Test
+    void translateChecksFromCfnToIot_NullIn_EmptyOut() {
+        ResourceModel input = ResourceModel.builder().build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEmpty();
+    }
+
+    @Test
+    void translateChecksFromCfnToIot_AllChecksArePresent_VerifyTranslation() {
+        Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> expectedResult =
+                DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT.auditCheckConfigurations();
+        ResourceModel input = ResourceModel.builder()
+                .auditCheckConfigurations(DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT_CFN).build();
+        assertThat(Translator.translateChecksFromCfnToIot(input)).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void translateChecksFromIotToCfn_AllChecksArePresent() {
+        Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> input =
+                DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT.auditCheckConfigurations();
+        assertThat(Translator.translateChecksFromIotToCfn(input)).isEqualTo(DESCRIBE_RESPONSE_ALL_CHECKS_PRESENT_CFN);
+    }
+
 }

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TranslatorTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TranslatorTest.java
@@ -4,6 +4,8 @@ import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NO
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_IOT;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE;
 import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE_CFN;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE_NON_EXISTENT_KEY_INGNORED_CFN;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE_WITH_NON_EXISTENT_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -16,7 +18,6 @@ import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 
 public class TranslatorTest {
-
     @Test
     public void translateExceptionToErrorCode_IRE_Translated() {
         HandlerErrorCode result = Translator.translateExceptionToErrorCode(
@@ -48,6 +49,13 @@ public class TranslatorTest {
     }
 
     @Test
+    void translateChecksFromIotToCfn_NonExistentKeyFromIot_VerifyIgnoredInTranslation() {
+        Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> input =
+                DESCRIBE_RESPONSE_V1_STATE_WITH_NON_EXISTENT_KEY.auditCheckConfigurations();
+        assertThat(Translator.translateChecksFromIotToCfn(input)).isEqualTo(DESCRIBE_RESPONSE_V1_STATE_NON_EXISTENT_KEY_INGNORED_CFN);
+    }
+
+    @Test
     void translateNotificationsFromCfnToIot_NonEmpty() {
         ResourceModel input = ResourceModel.builder()
                 .auditNotificationTargetConfigurations(AUDIT_NOTIFICATION_TARGET_CFN).build();
@@ -69,6 +77,6 @@ public class TranslatorTest {
 
     @Test
     void translateNotificationsFromIotToCfn_NullIn_EmptyOut() {
-        assertThat(Translator.translateNotificationsFromIotToCfn(null)).isEmpty();
+        assertThat(Translator.translateNotificationsFromIotToCfn(null)).isNull();
     }
 }

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/UpdateHandlerTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/UpdateHandlerTest.java
@@ -1,30 +1,6 @@
 package com.amazonaws.iot.accountauditconfiguration;
 
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ACCOUNT_ID;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_CHECK_CONFIGURATIONS_V2_CFN;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_V2_CFN;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_V2_IOT;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_REQUEST;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ZERO_STATE;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DISABLED_CFN;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DISABLED_IOT;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ENABLED_IOT;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ROLE_ARN;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.createCfnRequest;
-import static com.amazonaws.iot.accountauditconfiguration.TestConstants.getNotificationBuilderIot;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import com.google.common.collect.ImmutableMap;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,9 +18,29 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.Map;
+
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ACCOUNT_ID;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_CHECK_CONFIGURATIONS_V2_CFN;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_V2_CFN;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.AUDIT_NOTIFICATION_TARGET_V2_IOT;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_REQUEST;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_V1_STATE;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DESCRIBE_RESPONSE_ZERO_STATE;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.DISABLED_IOT;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ENABLED_IOT;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.ROLE_ARN;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.createCfnRequest;
+import static com.amazonaws.iot.accountauditconfiguration.TestConstants.getNotificationBuilderIot;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest {
-
     private static final Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> CHECK_CONFIGURATION_FROM_EXPECTED_UPDATE_REQUEST =
             ImmutableMap.of(
                     // enable 1, disable 1
@@ -121,25 +117,6 @@ public class UpdateHandlerTest {
     }
 
     @Test
-    public void buildCheckConfigurationsForUpdate_RequestHasNonExistentCheck_ExpectRetention() {
-
-        Map<String, AuditCheckConfiguration> checks = new HashMap<>(AUDIT_CHECK_CONFIGURATIONS_V2_CFN);
-        checks.put("NonExistentCheck", DISABLED_CFN);
-        ResourceModel model = ResourceModel.builder()
-                .auditCheckConfigurations(checks)
-                .build();
-
-        Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> actualResult =
-                handler.buildCheckConfigurationsForUpdate(model, DESCRIBE_RESPONSE_V1_STATE);
-
-        Map<String, software.amazon.awssdk.services.iot.model.AuditCheckConfiguration> expected =
-                new HashMap<>(CHECK_CONFIGURATION_FROM_EXPECTED_UPDATE_REQUEST);
-        expected.put("NonExistentCheck", DISABLED_IOT);
-
-        assertThat(actualResult).isEqualTo(expected);
-    }
-
-    @Test
     public void buildNotificationTargetConfigurationsForUpdate_NoneInModel_DisabledInResult() {
 
         ResourceModel model = ResourceModel.builder()
@@ -148,24 +125,6 @@ public class UpdateHandlerTest {
 
         Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget> expectedResult =
                 ImmutableMap.of("SNS", getNotificationBuilderIot().enabled(false).build());
-        Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget> actualResult =
-                handler.buildNotificationTargetConfigurationsForUpdate(model);
-        assertThat(actualResult).isEqualTo(expectedResult);
-    }
-
-    @Test
-    public void buildNotificationTargetConfigurationsForUpdate_NonExistentTarget_ExpectRetention() {
-
-        ImmutableMap<String, AuditNotificationTarget> notifications = ImmutableMap.of(
-                "NonExistent", AuditNotificationTarget.builder().enabled(false).build());
-        ResourceModel model = ResourceModel.builder()
-                .auditNotificationTargetConfigurations(notifications)
-                .build();
-
-        Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget> expectedResult =
-                ImmutableMap.of(
-                        "SNS", getNotificationBuilderIot().enabled(false).build(),
-                        "NonExistent", getNotificationBuilderIot().enabled(false).build());
         Map<String, software.amazon.awssdk.services.iot.model.AuditNotificationTarget> actualResult =
                 handler.buildNotificationTargetConfigurationsForUpdate(model);
         assertThat(actualResult).isEqualTo(expectedResult);


### PR DESCRIPTION
…er definded audit checks and alart target.

*Description of changes:*
- The model for AWS::IoT::AccountAuditConfiguration now has well defined checks as properties instead of a map with any string keys. 
- The AuditNotificationTargetConfigurations now has well defined alert targets as properties. 
These changes will make for a better user experience.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Ran all the contract tests and they all passed.