### PR TITLE
Handle the AccessDenied exception when it gets thrown as IotException

### DIFF
--- a/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/Translator.java
+++ b/aws-iot-accountauditconfiguration/src/main/java/com/amazonaws/iot/accountauditconfiguration/Translator.java
@@ -3,6 +3,7 @@ package com.amazonaws.iot.accountauditconfiguration;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.services.iot.model.InternalFailureException;
 import software.amazon.awssdk.services.iot.model.InvalidRequestException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.ThrottlingException;
 import software.amazon.awssdk.services.iot.model.UnauthorizedException;
 import software.amazon.awssdk.utils.CollectionUtils;
@@ -51,6 +52,8 @@ public class Translator {
             return HandlerErrorCode.InternalFailure;
         } else if (e instanceof ThrottlingException) {
             return HandlerErrorCode.Throttling;
+        } else if (e instanceof IotException && ((IotException) e).statusCode() == 403) {
+            return HandlerErrorCode.AccessDenied;
         } else {
             logger.log(String.format("Unexpected exception \"%s\", stack trace: %s",
                     e.getMessage(), ExceptionUtils.getStackTrace(e)));

--- a/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TranslatorTest.java
+++ b/aws-iot-accountauditconfiguration/src/test/java/com/amazonaws/iot/accountauditconfiguration/TranslatorTest.java
@@ -2,6 +2,7 @@ package com.amazonaws.iot.accountauditconfiguration;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.iot.model.InvalidRequestException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -28,6 +29,17 @@ public class TranslatorTest {
         HandlerErrorCode result = Translator.translateExceptionToErrorCode(
                 InvalidRequestException.builder().build(), mock(Logger.class));
         assertThat(result).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void translateIotExceptionToCfn_AccessDeniedErrorCode() {
+        HandlerErrorCode result =
+                Translator.translateExceptionToErrorCode(IotException.builder().statusCode(403)
+                        .message("User not authorised to perform on resource with an explicit deny " +
+                                "(Service: Iot, Status Code: 403, Request ID: dummy, " +
+                                "Extended Request ID: null), stack trace")
+                        .build(), mock(Logger.class));
+        assertThat(result).isEqualByComparingTo(HandlerErrorCode.AccessDenied);
     }
 
     @Test

--- a/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/Translator.java
+++ b/aws-iot-custommetric/src/main/java/com/amazonaws/iot/custommetric/Translator.java
@@ -3,6 +3,7 @@ package com.amazonaws.iot.custommetric;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.services.iot.model.InternalFailureException;
 import software.amazon.awssdk.services.iot.model.InvalidRequestException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.LimitExceededException;
 import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
 import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
@@ -69,6 +70,8 @@ public class Translator {
             return HandlerErrorCode.Throttling;
         } else if (e instanceof ResourceNotFoundException) {
             return HandlerErrorCode.NotFound;
+        } else if (e instanceof IotException && ((IotException) e).statusCode() == 403) {
+            return HandlerErrorCode.AccessDenied;
         } else {
             logger.log(String.format("Unexpected exception \"%s\", stack trace: %s",
                     e.getMessage(), ExceptionUtils.getStackTrace(e)));

--- a/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/TranslatorTest.java
+++ b/aws-iot-custommetric/src/test/java/com/amazonaws/iot/custommetric/TranslatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.awssdk.services.iot.model.IndexNotReadyException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.LimitExceededException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -35,6 +36,18 @@ public class TranslatorTest {
         IndexNotReadyException unexpectedException = IndexNotReadyException.builder().build();
         HandlerErrorCode result = Translator.translateExceptionToErrorCode(unexpectedException, logger);
         assertThat(result).isEqualByComparingTo(HandlerErrorCode.InternalFailure);
+    }
+
+    @Test
+    public void translateIotExceptionToCfn_AccessDeniedErrorCode() {
+
+        HandlerErrorCode result =
+                Translator.translateExceptionToErrorCode(IotException.builder().statusCode(403)
+                        .message("User not authorised to perform on resource with an explicit deny " +
+                                "(Service: Iot, Status Code: 403, Request ID: dummy, " +
+                                "Extended Request ID: null), stack trace")
+                        .build(), logger);
+        assertThat(result).isEqualByComparingTo(HandlerErrorCode.AccessDenied);
     }
 
     @Test

--- a/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/Translator.java
+++ b/aws-iot-dimension/src/main/java/com/amazonaws/iot/dimension/Translator.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.services.iot.model.InternalFailureException;
 import software.amazon.awssdk.services.iot.model.InvalidRequestException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.LimitExceededException;
 import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
 import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
@@ -67,6 +68,8 @@ public class Translator {
             return HandlerErrorCode.Throttling;
         } else if (e instanceof ResourceNotFoundException) {
             return HandlerErrorCode.NotFound;
+        } else if (e instanceof IotException && ((IotException) e).statusCode() == 403) {
+            return HandlerErrorCode.AccessDenied;
         } else {
             logger.log(String.format("Unexpected exception \"%s\", stack trace: %s",
                     e.getMessage(), ExceptionUtils.getStackTrace(e)));

--- a/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/TranslatorTest.java
+++ b/aws-iot-dimension/src/test/java/com/amazonaws/iot/dimension/TranslatorTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.iot.model.IndexNotReadyException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.LimitExceededException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -23,6 +24,17 @@ public class TranslatorTest {
         HandlerErrorCode result = Translator.translateExceptionToErrorCode(
                 IndexNotReadyException.builder().build(), mock(Logger.class));
         assertThat(result).isEqualTo(HandlerErrorCode.InternalFailure);
+    }
+
+    @Test
+    public void translateIotExceptionToCfn_AccessDeniedErrorCode() {
+        HandlerErrorCode result =
+                Translator.translateExceptionToErrorCode(IotException.builder().statusCode(403)
+                        .message("User not authorised to perform on resource with an explicit deny " +
+                                "(Service: Iot, Status Code: 403, Request ID: dummy, " +
+                                "Extended Request ID: null), stack trace")
+                        .build(), mock(Logger.class));
+        assertThat(result).isEqualByComparingTo(HandlerErrorCode.AccessDenied);
     }
 
     @Test

--- a/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/Translator.java
+++ b/aws-iot-mitigationaction/src/main/java/com/amazonaws/iot/mitigationaction/Translator.java
@@ -3,6 +3,7 @@ package com.amazonaws.iot.mitigationaction;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.services.iot.model.InternalFailureException;
 import software.amazon.awssdk.services.iot.model.InvalidRequestException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.LimitExceededException;
 import software.amazon.awssdk.services.iot.model.MitigationActionParams;
 import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
@@ -74,6 +75,8 @@ public class Translator {
             return HandlerErrorCode.Throttling;
         } else if (e instanceof ResourceNotFoundException) {
             return HandlerErrorCode.NotFound;
+        } else if (e instanceof IotException && ((IotException) e).statusCode() == 403) {
+            return HandlerErrorCode.AccessDenied;
         } else {
             logger.log(String.format("Unexpected exception \"%s\", stack trace: %s",
                     e.getMessage(), ExceptionUtils.getStackTrace(e)));

--- a/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/TranslatorTest.java
+++ b/aws-iot-mitigationaction/src/test/java/com/amazonaws/iot/mitigationaction/TranslatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.awssdk.services.iot.model.IndexNotReadyException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.LimitExceededException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -49,6 +50,18 @@ public class TranslatorTest {
         IndexNotReadyException unexpectedException = IndexNotReadyException.builder().build();
         HandlerErrorCode result = Translator.translateExceptionToErrorCode(unexpectedException, logger);
         assertThat(result).isEqualByComparingTo(HandlerErrorCode.InternalFailure);
+    }
+
+    @Test
+    public void translateIotExceptionToCfn_AccessDeniedErrorCode() {
+
+        HandlerErrorCode result =
+                Translator.translateExceptionToErrorCode(IotException.builder().statusCode(403)
+                        .message("User not authorised to perform on resource with an explicit deny " +
+                                "(Service: Iot, Status Code: 403, Request ID: dummy, " +
+                                "Extended Request ID: null), stack trace")
+                        .build(), logger);
+        assertThat(result).isEqualByComparingTo(HandlerErrorCode.AccessDenied);
     }
 
     @Test

--- a/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/Translator.java
+++ b/aws-iot-scheduledaudit/src/main/java/com/amazonaws/iot/scheduledaudit/Translator.java
@@ -3,6 +3,7 @@ package com.amazonaws.iot.scheduledaudit;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import software.amazon.awssdk.services.iot.model.InternalFailureException;
 import software.amazon.awssdk.services.iot.model.InvalidRequestException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.LimitExceededException;
 import software.amazon.awssdk.services.iot.model.ResourceAlreadyExistsException;
 import software.amazon.awssdk.services.iot.model.ResourceNotFoundException;
@@ -73,6 +74,8 @@ public class Translator {
             return HandlerErrorCode.Throttling;
         } else if (e instanceof ResourceNotFoundException) {
             return HandlerErrorCode.NotFound;
+        } else if (e instanceof IotException && ((IotException) e).statusCode() == 403) {
+            return HandlerErrorCode.AccessDenied;
         } else {
             logger.log(String.format("Unexpected exception \"%s\", stack trace: %s",
                     e.getMessage(), ExceptionUtils.getStackTrace(e)));

--- a/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/TranslatorTest.java
+++ b/aws-iot-scheduledaudit/src/test/java/com/amazonaws/iot/scheduledaudit/TranslatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.awssdk.services.iot.model.IndexNotReadyException;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.awssdk.services.iot.model.LimitExceededException;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -27,6 +28,18 @@ public class TranslatorTest {
         HandlerErrorCode result =
                 Translator.translateExceptionToErrorCode(LimitExceededException.builder().build(), logger);
         assertThat(result).isEqualByComparingTo(HandlerErrorCode.ServiceLimitExceeded);
+    }
+
+    @Test
+    public void translateIotExceptionToCfn_AccessDeniedErrorCode() {
+
+        HandlerErrorCode result =
+                Translator.translateExceptionToErrorCode(IotException.builder().statusCode(403)
+                        .message("User not authorised to perform on resource with an explicit deny " +
+                                "(Service: Iot, Status Code: 403, Request ID: dummy, " +
+                                "Extended Request ID: null), stack trace")
+                        .build(), logger);
+        assertThat(result).isEqualByComparingTo(HandlerErrorCode.AccessDenied);
     }
 
     @Test

--- a/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TranslatorTest.java
+++ b/aws-iot-securityprofile/src/test/java/com/amazonaws/iot/securityprofile/TranslatorTest.java
@@ -2,6 +2,7 @@ package com.amazonaws.iot.securityprofile;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.iot.model.IotException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 
 import java.util.ArrayList;
@@ -14,6 +15,9 @@ import static com.amazonaws.iot.securityprofile.Translator.translateBehaviorList
 import static com.amazonaws.iot.securityprofile.Translator.translateBehaviorSetFromCfnToIot;
 import static com.amazonaws.iot.securityprofile.Translator.translateMetricValueFromCfnToIot;
 import static com.amazonaws.iot.securityprofile.Translator.translateMetricValueFromIotToCfn;
+import static org.mockito.Mockito.mock;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.Logger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,6 +54,18 @@ public class TranslatorTest {
 
         Set<Behavior> actualCfnBehaviors = translateBehaviorListFromIotToCfn(new ArrayList<>(iotBehaviors));
         assertThat(actualCfnBehaviors).isEqualTo(cfnBehaviors);
+    }
+
+    @Test
+    public void translateIotExceptionToCfn_AccessDeniedErrorCode() {
+
+        HandlerErrorCode result =
+                Translator.translateExceptionToErrorCode(IotException.builder().statusCode(403)
+                        .message("User not authorised to perform on resource with an explicit deny " +
+                                "(Service: Iot, Status Code: 403, Request ID: dummy, " +
+                                "Extended Request ID: null), stack trace")
+                        .build(), mock(Logger.class));
+        assertThat(result).isEqualByComparingTo(HandlerErrorCode.AccessDenied);
     }
 
     private Behavior buildSourceIpBehaviorCfn() {


### PR DESCRIPTION
*Issue :*
1. Reference: https://t.corp.amazon.com/P45297910/communication.
2. The translator code was not handling the IotException for all the Iot Device Defender resources

*Description of changes:*
1. Adding the fix to handle the AccessDenied exception when it gets thrown as IotException for all Iot Device Defender resources.
2. Adding the corresponding unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
