### PR TITLE
Adds missing permission and minor fixes to schema

### DIFF
--- a/aws-iot-jobtemplate/aws-iot-jobtemplate.json
+++ b/aws-iot-jobtemplate/aws-iot-jobtemplate.json
@@ -157,7 +157,7 @@
     }
   },
   "properties": {
-    "JobTemplateArn": {
+    "Arn": {
       "type": "string"
     },
     "JobArn": {
@@ -229,7 +229,7 @@
         }
       },
       "required": [
-        "AbortCriteria"
+        "CriteriaList"
       ],
       "additionalProperties": false
     },
@@ -265,7 +265,7 @@
   ],
   "additionalProperties": false,
   "readOnlyProperties": [
-    "/properties/JobTemplateArn"
+    "/properties/Arn"
   ],
   "writeOnlyProperties": [
     "/properties/JobArn",
@@ -289,7 +289,9 @@
   "handlers": {
     "create": {
       "permissions": [
-        "iot:CreateJobTemplate"
+        "iot:CreateJobTemplate",
+        "iam:PassRole",
+        "s3:GetObject"
       ]
     },
     "read": {

--- a/aws-iot-jobtemplate/resource-role.yaml
+++ b/aws-iot-jobtemplate/resource-role.yaml
@@ -23,10 +23,12 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:PassRole"
                 - "iot:CreateJobTemplate"
                 - "iot:DeleteJobTemplate"
                 - "iot:DescribeJobTemplate"
                 - "iot:ListJobTemplates"
+                - "s3:GetObject"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-iot-jobtemplate/src/main/java/software/amazon/iot/jobtemplate/CreateHandler.java
+++ b/aws-iot-jobtemplate/src/main/java/software/amazon/iot/jobtemplate/CreateHandler.java
@@ -81,7 +81,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             logger.log(String.format("%s [%s] created successfully", ResourceModel.TYPE_NAME, model.getJobTemplateId()));
 
             return ProgressEvent.defaultSuccessHandler(ResourceModel.builder()
-                    .jobTemplateArn(response.jobTemplateArn())
+                    .arn(response.jobTemplateArn())
                     .jobTemplateId(response.jobTemplateId())
                     .abortConfig(model.getAbortConfig())
                     .description(model.getDescription())

--- a/aws-iot-jobtemplate/src/main/java/software/amazon/iot/jobtemplate/ListHandler.java
+++ b/aws-iot-jobtemplate/src/main/java/software/amazon/iot/jobtemplate/ListHandler.java
@@ -49,7 +49,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
             final List<ResourceModel> models = response.jobTemplates().stream()
                     .map(jobTemplateSummary -> ResourceModel.builder()
                             .jobTemplateId(jobTemplateSummary.jobTemplateId())
-                            .jobTemplateArn(jobTemplateSummary.jobTemplateArn())
+                            .arn(jobTemplateSummary.jobTemplateArn())
                             .description(jobTemplateSummary.description())
                             .build()
                     )

--- a/aws-iot-jobtemplate/src/main/java/software/amazon/iot/jobtemplate/ReadHandler.java
+++ b/aws-iot-jobtemplate/src/main/java/software/amazon/iot/jobtemplate/ReadHandler.java
@@ -61,7 +61,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
 
 
             return ProgressEvent.defaultSuccessHandler(ResourceModel.builder()
-                    .jobTemplateArn(response.jobTemplateArn())
+                    .arn(response.jobTemplateArn())
                     .jobTemplateId(response.jobTemplateId())
                     .abortConfig(abortConfig)
                     .description(response.description())

--- a/aws-iot-jobtemplate/src/test/java/software/amazon/iot/jobtemplate/CreateHandlerTest.java
+++ b/aws-iot-jobtemplate/src/test/java/software/amazon/iot/jobtemplate/CreateHandlerTest.java
@@ -62,7 +62,7 @@ public class CreateHandlerTest extends HandlerTestBase{
         final CreateJobTemplateResponse expectedResponse = getCreateResponse();
 
         final ResourceModel expectedModel = ResourceModel.builder()
-                .jobTemplateArn(JOB_TEMPLATE_ARN)
+                .arn(JOB_TEMPLATE_ARN)
                 .jobTemplateId(JOB_TEMPLATE_ID)
                 .description(JOB_TEMPLATE_DESCRIPTION)
                 .build();
@@ -100,7 +100,7 @@ public class CreateHandlerTest extends HandlerTestBase{
 
         final ResourceModel expectedModel = ResourceModel.builder()
                 .jobTemplateId(JOB_TEMPLATE_ID)
-                .jobTemplateArn(JOB_TEMPLATE_ARN)
+                .arn(JOB_TEMPLATE_ARN)
                 .description(JOB_TEMPLATE_DESCRIPTION)
                 .abortConfig(model.getAbortConfig())
                 .jobExecutionsRolloutConfig(model.getJobExecutionsRolloutConfig())

--- a/aws-iot-jobtemplate/src/test/java/software/amazon/iot/jobtemplate/ListHandlerTest.java
+++ b/aws-iot-jobtemplate/src/test/java/software/amazon/iot/jobtemplate/ListHandlerTest.java
@@ -67,7 +67,7 @@ public class ListHandlerTest extends HandlerTestBase{
         for(JobTemplateSummary summary : expectedResponse.jobTemplates()) {
             expectedModels.add(ResourceModel.builder()
                     .jobTemplateId(summary.jobTemplateId())
-                    .jobTemplateArn(summary.jobTemplateArn())
+                    .arn(summary.jobTemplateArn())
                     .build());
         }
 

--- a/aws-iot-jobtemplate/src/test/java/software/amazon/iot/jobtemplate/ReadHandlerTest.java
+++ b/aws-iot-jobtemplate/src/test/java/software/amazon/iot/jobtemplate/ReadHandlerTest.java
@@ -63,7 +63,7 @@ public class ReadHandlerTest extends HandlerTestBase{
 
         final ResourceModel expectedModel = ResourceModel.builder()
                 .jobTemplateId(JOB_TEMPLATE_ID)
-                .jobTemplateArn(JOB_TEMPLATE_ARN)
+                .arn(JOB_TEMPLATE_ARN)
                 .description(JOB_TEMPLATE_DESCRIPTION)
                 .abortConfig(Translator.getAbortConfig(expectedResponse.abortConfig()))
                 .jobExecutionsRolloutConfig(Translator.getJobExecutionsRolloutConfig(expectedResponse.jobExecutionsRolloutConfig()))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed JobTemplateArn to Arn to conform to convention. CriteriaList is required but AbortCriteria cannot be due to template format. Jobs requires s3GetObject and PassRole permissions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
