### PR TITLE
handle case where fleet indexing is not enabled

### DIFF
--- a/aws-iot-thinggroup/src/main/java/software/amazon/iot/thinggroup/Translator.java
+++ b/aws-iot-thinggroup/src/main/java/software/amazon/iot/thinggroup/Translator.java
@@ -65,6 +65,9 @@ public class Translator {
         if (e instanceof ResourceAlreadyExistsException) {
             return new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, resourceIdentifier, e);
         } else if (e instanceof ResourceNotFoundException) {
+            if (e.getMessage()!= null && e.getMessage().contains("AWS IoT Fleet Indexing is not enabled")) {
+                return new CfnInvalidRequestException(e);
+            }
             return new CfnNotFoundException(ResourceModel.TYPE_NAME, resourceIdentifier, e);
         } else if (e instanceof UnauthorizedException) {
             return new CfnAccessDeniedException(e);

--- a/aws-iot-thinggroup/src/test/java/software/amazon/iot/thinggroup/CreateHandlerTest.java
+++ b/aws-iot-thinggroup/src/test/java/software/amazon/iot/thinggroup/CreateHandlerTest.java
@@ -600,4 +600,27 @@ public class CreateHandlerTest extends AbstractTestBase {
         verify(iotClient).describeThingGroup(any(DescribeThingGroupRequest.class));
         verify(iotClient).createDynamicThingGroup(any(CreateDynamicThingGroupRequest.class));
     }
+
+    @Test
+    public void handleRequest_DynamicThingGroupCreate_FleetIndexingNotEnabled() {
+        final ResourceModel model = ResourceModel.builder()
+                .thingGroupName(TG_NAME)
+                .queryString(DG_QUERYSTRING)
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = defaultRequestBuilder(model).build();
+
+        ResourceNotFoundException resourceNotFoundException = ResourceNotFoundException.builder()
+                .message("AWS IoT Fleet Indexing is not enabled. Please enable index by calling UpdateIndexingConfiguration.")
+                .build();
+
+        when(iotClient.describeThingGroup(any(DescribeThingGroupRequest.class)))
+                .thenThrow(ResourceNotFoundException.class);
+        when(iotClient.createDynamicThingGroup(any(CreateDynamicThingGroupRequest.class)))
+                .thenThrow(resourceNotFoundException);
+
+        assertThrows(CfnInvalidRequestException.class, () ->
+                handler.handleRequest(proxy, request, new CallbackContext(),proxyClient,LOGGER));
+        verify(iotClient).describeThingGroup(any(DescribeThingGroupRequest.class));
+        verify(iotClient).createDynamicThingGroup(any(CreateDynamicThingGroupRequest.class));
+    }
 }


### PR DESCRIPTION
### Description of changes:
Dynamic Thing group API requests with throw a `ResourceNotFound` exception when Fleet Indexing is not enabled for the account-region. We need to surface that message to the customer - as a form of Invalid Requests. The change handles this particular case.

### Testing
- manually tested by disabling fleet indexing and creating a dynamic group
- contract tests successful


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
