### PR TITLE
remove maxlength from attributes object type

### DIFF
--- a/aws-iot-thinggroup/aws-iot-thinggroup.json
+++ b/aws-iot-thinggroup/aws-iot-thinggroup.json
@@ -58,7 +58,6 @@
       "properties": {
         "Attributes": {
           "type": "object",
-          "maxLength": 2800,
           "patternProperties": {
             "[a-zA-Z0-9_.,@/:#-]+": {
               "type": "string"


### PR DESCRIPTION
### Description of changes
removing the `maxLength` attribute from schema - warning seen as part of `cfn validate` 

```
❯ cfn validate
Incorrect JSON schema keyword(s) {'maxLength'} for type: object for property: Attributes
```

### Testing
- contract tests are successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
