### PR TITLE
Adding unique name to contract test resources

### DIFF
--- a/aws-iot-billinggroup/contract-tests-artifacts/inputs_1.json
+++ b/aws-iot-billinggroup/contract-tests-artifacts/inputs_1.json
@@ -1,6 +1,6 @@
 {
   "CreateInputs": {
-    "BillingGroupName": "CfnContractTestBillingGroup",
+    "BillingGroupName": "{{uuid}}",
     "BillingGroupProperties": {
       "BillingGroupDescription": "test BillingGroup for Cfn Contract Tests"
     },

--- a/aws-iot-thinggroup/contract-tests-artifacts/inputs_1.json
+++ b/aws-iot-thinggroup/contract-tests-artifacts/inputs_1.json
@@ -1,6 +1,6 @@
 {
   "CreateInputs": {
-    "ThingGroupName": "CfnContractTestThingGroup",
+    "ThingGroupName": "{{uuid}}",
     "ThingGroupProperties": {
       "ThingGroupDescription": "test ThingGroup for Cfn Contract Tests",
       "AttributePayload": {

--- a/aws-iot-thinggroup/contract-tests-artifacts/inputs_2.json
+++ b/aws-iot-thinggroup/contract-tests-artifacts/inputs_2.json
@@ -1,6 +1,6 @@
 {
   "CreateInputs": {
-    "ThingGroupName": "CfnContractTestThingGroup",
+    "ThingGroupName": "{{uuid}}",
     "ParentGroupName": "CfnContractTestThingGroupParent",
     "ThingGroupProperties": {
       "ThingGroupDescription": "test ThingGroup for Cfn Contract Tests"

--- a/aws-iot-thinggroup/contract-tests-artifacts/inputs_3.json
+++ b/aws-iot-thinggroup/contract-tests-artifacts/inputs_3.json
@@ -1,6 +1,6 @@
 {
   "CreateInputs": {
-    "ThingGroupName": "CfnContractTestDynamicThingGroup",
+    "ThingGroupName": "{{uuid}}",
     "QueryString": "attributes.temperature>60",
     "ThingGroupProperties": {
       "ThingGroupDescription": "test dynamic ThingGroup for Cfn Contract Tests"

--- a/aws-iot-thingtype/contract-tests-artifacts/inputs_1.json
+++ b/aws-iot-thingtype/contract-tests-artifacts/inputs_1.json
@@ -1,6 +1,6 @@
 {
   "CreateInputs": {
-    "ThingTypeName": "CfnContractTestThingType",
+    "ThingTypeName": "{{uuid}}",
     "DeprecateThingType": false,
     "ThingTypeProperties": {
       "ThingTypeDescription": "test ThingType for Cfn Contract Tests",


### PR DESCRIPTION
*Description of changes:*
Add unique names to contract test inputs to avoid resource leakage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
